### PR TITLE
fix: properly pass client API keys to AI providers

### DIFF
--- a/src/lib/create-model.ts
+++ b/src/lib/create-model.ts
@@ -1,46 +1,47 @@
-import { anthropic as createAnthropic } from "@ai-sdk/anthropic";
-import { openai as createOpenai } from "@ai-sdk/openai";
-import { google as createGoogle } from "@ai-sdk/google";
-import { xai as createXai } from "@ai-sdk/xai";
-import { mistral as createMistral } from "@ai-sdk/mistral";
-import { groq as createGroq } from "@ai-sdk/groq";
-import { deepseek as createDeepseek } from "@ai-sdk/deepseek";
-import { perplexity as createPerplexity } from "@ai-sdk/perplexity";
-import { cohere as createCohere } from "@ai-sdk/cohere";
-import { cerebras as createCerebras } from "@ai-sdk/cerebras";
-import { togetherai as createTogetherai } from "@ai-sdk/togetherai";
-import { fireworks as createFireworks } from "@ai-sdk/fireworks";
-import { moonshotai as createMoonshotai } from "@ai-sdk/moonshotai";
-import { alibaba as createAlibaba } from "@ai-sdk/alibaba";
-import { deepinfra as createDeepinfra } from "@ai-sdk/deepinfra";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createXai } from "@ai-sdk/xai";
+import { createMistral } from "@ai-sdk/mistral";
+import { createGroq } from "@ai-sdk/groq";
+import { createDeepSeek } from "@ai-sdk/deepseek";
+import { createPerplexity } from "@ai-sdk/perplexity";
+import { createCohere } from "@ai-sdk/cohere";
+import { createCerebras } from "@ai-sdk/cerebras";
+import { createTogetherAI } from "@ai-sdk/togetherai";
+import { createFireworks } from "@ai-sdk/fireworks";
+import { createMoonshotAI } from "@ai-sdk/moonshotai";
+import { createAlibaba } from "@ai-sdk/alibaba";
+import { createDeepInfra } from "@ai-sdk/deepinfra";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ProviderFactory = (modelId: string, opts?: any) => any;
+type ProviderFactory = (opts?: { apiKey?: string }) => (modelId: string) => any;
 
 const providers: Record<string, ProviderFactory> = {
-  anthropic: createAnthropic,
-  openai: createOpenai,
-  google: createGoogle,
-  xai: createXai,
-  mistral: createMistral,
-  groq: createGroq,
-  deepseek: createDeepseek,
-  perplexity: createPerplexity,
-  cohere: createCohere,
-  cerebras: createCerebras,
-  togetherai: createTogetherai,
-  fireworks: createFireworks,
-  moonshotai: createMoonshotai,
-  alibaba: createAlibaba,
-  deepinfra: createDeepinfra,
+  anthropic: (opts) => createAnthropic(opts),
+  openai: (opts) => createOpenAI(opts),
+  google: (opts) => createGoogleGenerativeAI(opts),
+  xai: (opts) => createXai(opts),
+  mistral: (opts) => createMistral(opts),
+  groq: (opts) => createGroq(opts),
+  deepseek: (opts) => createDeepSeek(opts),
+  perplexity: (opts) => createPerplexity(opts),
+  cohere: (opts) => createCohere(opts),
+  cerebras: (opts) => createCerebras(opts),
+  togetherai: (opts) => createTogetherAI(opts),
+  fireworks: (opts) => createFireworks(opts),
+  moonshotai: (opts) => createMoonshotAI(opts),
+  alibaba: (opts) => createAlibaba(opts),
+  deepinfra: (opts) => createDeepInfra(opts),
 };
 
 export function createModel(modelStr: string, apiKey?: string) {
   const idx = modelStr.indexOf(":");
   const providerId = idx === -1 ? "anthropic" : modelStr.slice(0, idx);
   const modelId = idx === -1 ? modelStr : modelStr.slice(idx + 1);
-  const factory = providers[providerId] ?? createAnthropic;
-  return factory(modelId, apiKey ? { apiKey } : undefined);
+  const factory = providers[providerId] ?? providers.anthropic;
+  const provider = factory(apiKey ? { apiKey } : undefined);
+  return provider(modelId);
 }
 
 export function isAnthropicModel(modelStr: string): boolean {


### PR DESCRIPTION
## Summary

- Uses provider factory functions (`createAnthropic`, `createOpenAI`, etc.) instead of pre-configured default instances
- Client-provided API keys are now correctly passed when creating provider instances
- Previously, keys were passed as model-level settings and silently ignored — the providers only read from env vars

This fixes the `AI_LoadAPIKeyError` seen when deploying without server-side env vars (e.g. on a Droplet), where the app relies entirely on client-provided keys from localStorage.

## Test plan

- [x] Existing `create-model.test.ts` tests pass
- [x] Lint and typecheck pass via pre-commit hooks
- [ ] Verify on deployed Droplet: select a model, paste API key in UI, send a message — should work without `ANTHROPIC_API_KEY` env var