### PR TITLE
feat: add support for Claude Max, Gemini Plan, and Codex subscription plans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,13 @@ DEEPINFRA_API_KEY=
 CEREBRAS_API_KEY=
 MOONSHOT_API_KEY=
 ALIBABA_API_KEY=
+
+# --- Subscription Plan Proxies ---
+# Use Claude Max, Gemini Pro/Ultra, or ChatGPT Plus/Codex subscriptions
+# through CLI proxy tools like CLIProxyAPI.
+# These proxy your subscription through the official CLIs (Claude Code,
+# Gemini CLI, Codex CLI) and expose an OpenAI-compatible API.
+# See: https://github.com/router-for-me/CLIProxyAPI
+#
+# Plan endpoints are configured per-user in the UI. No env vars needed
+# unless you want to set a default proxy endpoint for all users.

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -124,6 +124,7 @@ export async function POST(request: Request) {
     widgetId,
     model: modelStr,
     apiKey,
+    planEndpoint,
     searchProvider,
     searchApiKey,
   } = body as {
@@ -134,6 +135,7 @@ export async function POST(request: Request) {
     widgetId: string;
     model?: string;
     apiKey?: string;
+    planEndpoint?: string;
     searchProvider?: SearchProvider;
     searchApiKey?: string;
   };
@@ -143,7 +145,7 @@ export async function POST(request: Request) {
   }
 
   const selectedModel = modelStr ?? "anthropic:claude-sonnet-4-6";
-  const useAnthropic = isAnthropicModel(selectedModel);
+  const useAnthropic = isAnthropicModel(selectedModel) && !planEndpoint;
 
   const SANDBOX_ROOT = "/widget";
 
@@ -250,7 +252,7 @@ export async function POST(request: Request) {
   }
 
   const result = streamText({
-    model: createModel(selectedModel, apiKey),
+    model: createModel(selectedModel, { apiKey, planEndpoint }),
     system: SYSTEM_PROMPT,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     messages: messages as any,

--- a/src/app/api/generate-title/route.ts
+++ b/src/app/api/generate-title/route.ts
@@ -2,10 +2,11 @@ import { generateText } from "ai";
 import { createModel } from "@/lib/create-model";
 
 export async function POST(request: Request) {
-  const { message, model, apiKey } = (await request.json()) as {
+  const { message, model, apiKey, planEndpoint } = (await request.json()) as {
     message: string;
     model?: string;
     apiKey?: string;
+    planEndpoint?: string;
   };
 
   if (!message?.trim()) {
@@ -14,7 +15,7 @@ export async function POST(request: Request) {
 
   try {
     const { text } = await generateText({
-      model: createModel(model ?? "anthropic:claude-haiku-4-5", apiKey),
+      model: createModel(model ?? "anthropic:claude-haiku-4-5", { apiKey, planEndpoint }),
       prompt: `Generate a short widget title (2-4 words max, no punctuation) for this request: "${message}". Reply with only the title, nothing else.`,
     });
 

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -43,7 +43,14 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useWidgetStore, type WidgetMessage, type MessageAttachment } from "@/store/widget-store";
 import { useSettingsStore } from "@/store/settings-store";
-import { PROVIDERS, parseModelString, findProvider } from "@/lib/model-registry";
+import {
+  PROVIDERS,
+  PLAN_PROVIDERS,
+  parseModelString,
+  findProvider,
+  findPlanProvider,
+  isPlanProvider,
+} from "@/lib/model-registry";
 import { SearchProviderPicker } from "@/components/search-provider-picker";
 
 interface PendingFile {
@@ -211,6 +218,7 @@ async function streamToWidget(
   messages: Array<{ role: "user" | "assistant"; content: string | Record<string, unknown>[] }>,
   model?: string,
   apiKey?: string,
+  planEndpoint?: string,
 ) {
   const {
     addMessage,
@@ -253,6 +261,7 @@ async function streamToWidget(
         widgetId,
         model,
         apiKey,
+        ...(planEndpoint ? { planEndpoint } : {}),
         ...(searchProvider && searchApiKey ? { searchProvider, searchApiKey } : {}),
       }),
       signal: controller.signal,
@@ -367,23 +376,47 @@ function useModelSelector() {
   const setModel = useSettingsStore((s) => s.setModel);
   const apiKeys = useSettingsStore((s) => s.apiKeys);
   const setApiKey = useSettingsStore((s) => s.setApiKey);
+  const planEndpoints = useSettingsStore((s) => s.planEndpoints);
+  const setPlanEndpoint = useSettingsStore((s) => s.setPlanEndpoint);
   const [open, setOpen] = useState(false);
   const [keyInput, setKeyInput] = useState("");
+  const [endpointInput, setEndpointInput] = useState("");
   const [showKeyInput, setShowKeyInput] = useState(false);
+  const [showEndpointInput, setShowEndpointInput] = useState(false);
 
   const { providerId, modelId } = parseModelString(selectedModel);
+  const isPlan = isPlanProvider(providerId);
   const provider = findProvider(providerId);
-  const model = provider?.models.find((m) => m.id === modelId);
-  const hasKey = !!apiKeys[providerId];
+  const planProvider = findPlanProvider(providerId);
+  const model =
+    provider?.models.find((m) => m.id === modelId) ??
+    planProvider?.models.find((m) => m.id === modelId);
+  const hasKey = isPlan ? !!planEndpoints[providerId] : !!apiKeys[providerId];
+  const logoProvider = isPlan ? (planProvider?.logoProvider ?? providerId) : providerId;
 
   const handleSelect = (newModel: string) => {
     setModel(newModel);
     setOpen(false);
     const { providerId: pid } = parseModelString(newModel);
-    if (!apiKeys[pid]) {
-      setShowKeyInput(true);
+    const newIsPlan = isPlanProvider(pid);
+    if (newIsPlan) {
+      if (!planEndpoints[pid]) {
+        const pp = findPlanProvider(pid);
+        setEndpointInput(pp?.defaultEndpoint ?? "http://localhost:8080/v1");
+        setShowEndpointInput(true);
+        setShowKeyInput(false);
+      } else {
+        setShowEndpointInput(false);
+        setShowKeyInput(false);
+      }
     } else {
-      setShowKeyInput(false);
+      if (!apiKeys[pid]) {
+        setShowKeyInput(true);
+        setShowEndpointInput(false);
+      } else {
+        setShowKeyInput(false);
+        setShowEndpointInput(false);
+      }
     }
   };
 
@@ -395,11 +428,20 @@ function useModelSelector() {
     }
   };
 
+  const handleSaveEndpoint = () => {
+    if (endpointInput.trim()) {
+      setPlanEndpoint(providerId, endpointInput.trim());
+      setEndpointInput("");
+      setShowEndpointInput(false);
+    }
+  };
+
   const trigger = (
     <ModelSelector open={open} onOpenChange={setOpen}>
       <ModelSelectorTrigger className="inline-flex h-7 items-center gap-1.5 px-2 text-xs text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors cursor-pointer">
-        <ModelSelectorLogo provider={providerId as "anthropic"} className="size-3.5" />
+        <ModelSelectorLogo provider={logoProvider as "anthropic"} className="size-3.5" />
         <span>{model?.name ?? modelId}</span>
+        {isPlan && <span className="text-[9px] text-emerald-500/70 uppercase tracking-wider">plan</span>}
         {!hasKey && <span className="size-1.5 rounded-full bg-yellow-500/70 shrink-0" />}
       </ModelSelectorTrigger>
       <ModelSelectorContent>
@@ -421,12 +463,32 @@ function useModelSelector() {
               ))}
             </ModelSelectorGroup>
           ))}
+          <ModelSelectorGroup heading="Subscription Plans">
+            {PLAN_PROVIDERS.flatMap((p) =>
+              p.models.map((m) => (
+                <ModelSelectorItem
+                  key={`${p.id}:${m.id}`}
+                  value={`${p.id}:${m.id} ${m.name} ${p.name} plan subscription`}
+                  onSelect={() => handleSelect(`${p.id}:${m.id}`)}
+                  className="flex items-center gap-2"
+                >
+                  <ModelSelectorLogo provider={p.logoProvider as "anthropic"} />
+                  <ModelSelectorName>
+                    {m.name}
+                    <span className="ml-1.5 text-[10px] text-emerald-500/70 uppercase tracking-wider">
+                      {p.name}
+                    </span>
+                  </ModelSelectorName>
+                </ModelSelectorItem>
+              ))
+            )}
+          </ModelSelectorGroup>
         </ModelSelectorList>
       </ModelSelectorContent>
     </ModelSelector>
   );
 
-  const keyInputEl = (showKeyInput || !hasKey) ? (
+  const keyInputEl = !isPlan && (showKeyInput || !hasKey) ? (
     <div className="flex items-center gap-1.5">
       <input
         type="password"
@@ -445,11 +507,44 @@ function useModelSelector() {
     </div>
   ) : null;
 
-  return { trigger, keyInputEl };
+  const endpointInputEl = isPlan && (showEndpointInput || !hasKey) ? (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <input
+          type="text"
+          value={endpointInput}
+          onChange={(e) => setEndpointInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSaveEndpoint()}
+          placeholder={planProvider?.defaultEndpoint ?? "http://localhost:8080/v1"}
+          className="flex-1 bg-zinc-900 border border-zinc-800 text-xs px-2.5 py-1.5 text-zinc-300 placeholder:text-zinc-600 focus:outline-none focus:border-zinc-600"
+        />
+        <button
+          onClick={handleSaveEndpoint}
+          className="px-2.5 py-1.5 text-xs uppercase tracking-wider bg-zinc-800 hover:bg-zinc-700 text-zinc-300 transition-colors"
+        >
+          Save
+        </button>
+      </div>
+      <p className="text-[10px] text-zinc-500 leading-relaxed">
+        Requires a CLI proxy (e.g.{" "}
+        <a
+          href={planProvider?.setupUrl ?? "https://github.com/router-for-me/CLIProxyAPI"}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-zinc-400 underline underline-offset-2 hover:text-zinc-300"
+        >
+          CLIProxyAPI
+        </a>
+        ) to route requests through your {planProvider?.name ?? "subscription"}.
+      </p>
+    </div>
+  ) : null;
+
+  return { trigger, keyInputEl, endpointInputEl };
 }
 
 export function ChatSidebar() {
-  const { trigger: modelTrigger, keyInputEl: modelKeyInput } = useModelSelector();
+  const { trigger: modelTrigger, keyInputEl: modelKeyInput, endpointInputEl: modelEndpointInput } = useModelSelector();
   const widgets = useWidgetStore((s) => s.widgets);
   const activeWidgetId = useWidgetStore((s) => s.activeWidgetId);
   const streamingWidgetIds = useWidgetStore((s) => s.streamingWidgetIds);
@@ -647,15 +742,22 @@ export function ChatSidebar() {
       attachments,
     });
 
-    const { selectedModel, apiKeys } = useSettingsStore.getState();
+    const { selectedModel, apiKeys, planEndpoints } = useSettingsStore.getState();
     const { providerId } = parseModelString(selectedModel);
-    const byokKey = apiKeys[providerId];
+    const providerIsPlan = isPlanProvider(providerId);
+    const byokKey = providerIsPlan ? undefined : apiKeys[providerId];
+    const endpoint = providerIsPlan ? planEndpoints[providerId] : undefined;
 
     if (isFirstUserMessage && userContent) {
       fetch("/api/generate-title", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: userContent, model: selectedModel, apiKey: byokKey }),
+        body: JSON.stringify({
+          message: userContent,
+          model: selectedModel,
+          apiKey: byokKey,
+          ...(endpoint ? { planEndpoint: endpoint } : {}),
+        }),
       })
         .then((res) => res.ok ? res.json() : null)
         .then((data) => {
@@ -664,7 +766,7 @@ export function ChatSidebar() {
         .catch(() => {});
     }
 
-    streamToWidget(widgetId, messagesForApi, selectedModel, byokKey);
+    streamToWidget(widgetId, messagesForApi, selectedModel, byokKey, endpoint);
   }
 
   return (
@@ -739,6 +841,7 @@ export function ChatSidebar() {
 
         <div className="px-5 py-3 space-y-2">
           {modelKeyInput}
+          {modelEndpointInput}
           <PromptInput onSubmit={handleSubmit}>
             {pendingFiles.length > 0 && (
               <div className="flex flex-wrap gap-1.5">

--- a/src/lib/create-model.ts
+++ b/src/lib/create-model.ts
@@ -13,6 +13,7 @@ import { createFireworks } from "@ai-sdk/fireworks";
 import { createMoonshotAI } from "@ai-sdk/moonshotai";
 import { createAlibaba } from "@ai-sdk/alibaba";
 import { createDeepInfra } from "@ai-sdk/deepinfra";
+import { isPlanProvider } from "@/lib/model-registry";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ProviderFactory = (opts?: { apiKey?: string }) => (modelId: string) => any;
@@ -35,12 +36,29 @@ const providers: Record<string, ProviderFactory> = {
   deepinfra: (opts) => createDeepInfra(opts),
 };
 
-export function createModel(modelStr: string, apiKey?: string) {
+export interface CreateModelOptions {
+  apiKey?: string;
+  planEndpoint?: string;
+}
+
+export function createModel(modelStr: string, optsOrApiKey?: string | CreateModelOptions) {
+  const opts: CreateModelOptions =
+    typeof optsOrApiKey === "string" ? { apiKey: optsOrApiKey } : optsOrApiKey ?? {};
+
   const idx = modelStr.indexOf(":");
   const providerId = idx === -1 ? "anthropic" : modelStr.slice(0, idx);
   const modelId = idx === -1 ? modelStr : modelStr.slice(idx + 1);
+
+  if (isPlanProvider(providerId) && opts.planEndpoint) {
+    const proxy = createOpenAI({
+      baseURL: opts.planEndpoint,
+      apiKey: opts.apiKey || "plan-subscription",
+    });
+    return proxy(modelId);
+  }
+
   const factory = providers[providerId] ?? providers.anthropic;
-  const provider = factory(apiKey ? { apiKey } : undefined);
+  const provider = factory(opts.apiKey ? { apiKey: opts.apiKey } : undefined);
   return provider(modelId);
 }
 

--- a/src/lib/model-registry.ts
+++ b/src/lib/model-registry.ts
@@ -12,6 +12,16 @@ export interface ProviderInfo {
   models: ModelInfo[];
 }
 
+export interface PlanProviderInfo {
+  id: string;
+  name: string;
+  description: string;
+  defaultEndpoint: string;
+  setupUrl: string;
+  logoProvider: string;
+  models: ModelInfo[];
+}
+
 function models(
   providerId: string,
   providerName: string,
@@ -185,12 +195,69 @@ export const PROVIDERS: ProviderInfo[] = [
   },
 ];
 
+export const PLAN_PROVIDERS: PlanProviderInfo[] = [
+  {
+    id: "claude-max",
+    name: "Claude Max",
+    description: "Use your Claude Pro/Max subscription via a CLI proxy (e.g. CLIProxyAPI)",
+    defaultEndpoint: "http://localhost:8080/v1",
+    setupUrl: "https://github.com/router-for-me/CLIProxyAPI",
+    logoProvider: "anthropic",
+    models: models("claude-max", "Claude Max", [
+      ["claude-opus-4-6", "Claude Opus 4.6"],
+      ["claude-sonnet-4-6", "Claude Sonnet 4.6"],
+      ["claude-sonnet-4-5", "Claude Sonnet 4.5"],
+      ["claude-haiku-4-5", "Claude Haiku 4.5"],
+    ]),
+  },
+  {
+    id: "gemini-plan",
+    name: "Gemini Plan",
+    description: "Use your Gemini Pro/Ultra subscription via a CLI proxy (e.g. CLIProxyAPI)",
+    defaultEndpoint: "http://localhost:8080/v1",
+    setupUrl: "https://github.com/router-for-me/CLIProxyAPI",
+    logoProvider: "google",
+    models: models("gemini-plan", "Gemini Plan", [
+      ["gemini-2.5-pro", "Gemini 2.5 Pro"],
+      ["gemini-2.5-flash", "Gemini 2.5 Flash"],
+      ["gemini-3.1-pro-preview", "Gemini 3.1 Pro"],
+      ["gemini-3-flash-preview", "Gemini 3 Flash"],
+    ]),
+  },
+  {
+    id: "codex-plan",
+    name: "Codex / ChatGPT",
+    description: "Use your ChatGPT Plus/Pro or Codex subscription via a CLI proxy (e.g. CLIProxyAPI)",
+    defaultEndpoint: "http://localhost:8080/v1",
+    setupUrl: "https://github.com/router-for-me/CLIProxyAPI",
+    logoProvider: "openai",
+    models: models("codex-plan", "Codex / ChatGPT", [
+      ["gpt-5.4", "GPT-5.4"],
+      ["gpt-5.4-pro", "GPT-5.4 Pro"],
+      ["gpt-5.3-codex", "GPT-5.3 Codex"],
+      ["gpt-5-codex", "GPT-5 Codex"],
+      ["gpt-5", "GPT-5"],
+      ["gpt-5-mini", "GPT-5 Mini"],
+    ]),
+  },
+];
+
 export const ALL_MODELS = PROVIDERS.flatMap((p) => p.models);
+
+export const ALL_PLAN_MODELS = PLAN_PROVIDERS.flatMap((p) => p.models);
 
 export const DEFAULT_MODEL = "anthropic:claude-sonnet-4-6";
 
 export function findProvider(providerId: string): ProviderInfo | undefined {
   return PROVIDERS.find((p) => p.id === providerId);
+}
+
+export function findPlanProvider(providerId: string): PlanProviderInfo | undefined {
+  return PLAN_PROVIDERS.find((p) => p.id === providerId);
+}
+
+export function isPlanProvider(providerId: string): boolean {
+  return PLAN_PROVIDERS.some((p) => p.id === providerId);
 }
 
 export function parseModelString(modelStr: string): { providerId: string; modelId: string } {

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -6,11 +6,15 @@ import type { SearchProvider } from "@/lib/web-search";
 interface SettingsStore {
   selectedModel: string;
   apiKeys: Record<string, string>;
+  planEndpoints: Record<string, string>;
   searchProvider: SearchProvider | null;
   setModel: (model: string) => void;
   setApiKey: (provider: string, key: string) => void;
   removeApiKey: (provider: string) => void;
   getApiKey: (provider: string) => string | undefined;
+  setPlanEndpoint: (provider: string, endpoint: string) => void;
+  removePlanEndpoint: (provider: string) => void;
+  getPlanEndpoint: (provider: string) => string | undefined;
   setSearchProvider: (provider: SearchProvider | null) => void;
 }
 
@@ -19,6 +23,7 @@ export const useSettingsStore = create<SettingsStore>()(
     (set, get) => ({
       selectedModel: DEFAULT_MODEL,
       apiKeys: {},
+      planEndpoints: {},
       searchProvider: null,
 
       setModel: (model) => set({ selectedModel: model }),
@@ -36,6 +41,20 @@ export const useSettingsStore = create<SettingsStore>()(
         }),
 
       getApiKey: (provider) => get().apiKeys[provider],
+
+      setPlanEndpoint: (provider, endpoint) =>
+        set((state) => ({
+          planEndpoints: { ...state.planEndpoints, [provider]: endpoint },
+        })),
+
+      removePlanEndpoint: (provider) =>
+        set((state) => {
+          const next = { ...state.planEndpoints };
+          delete next[provider];
+          return { planEndpoints: next };
+        }),
+
+      getPlanEndpoint: (provider) => get().planEndpoints[provider],
 
       setSearchProvider: (provider) => set({ searchProvider: provider }),
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add subscription plan support that allows users to use their AI subscription plans (Claude Pro/Max, Gemini Pro/Ultra, ChatGPT Plus/Pro/Codex) as an alternative to raw API keys. Uses the established CLI proxy pattern (e.g. [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)) which wraps official CLIs as subprocesses and exposes OpenAI-compatible endpoints.

**New plan providers:**
- **Claude Max** — Claude Opus 4.6, Sonnet 4.6, Sonnet 4.5, Haiku 4.5
- **Gemini Plan** — Gemini 2.5 Pro, 2.5 Flash, 3.1 Pro, 3 Flash
- **Codex / ChatGPT** — GPT-5.4, GPT-5.4 Pro, GPT-5.3 Codex, GPT-5 Codex, GPT-5, GPT-5 Mini

**Key changes:**
- `model-registry.ts` — `PlanProviderInfo` type, `PLAN_PROVIDERS` array, `isPlanProvider()` / `findPlanProvider()` helpers
- `create-model.ts` — `CreateModelOptions` interface; plan providers route through `@ai-sdk/openai` with a custom `baseURL`
- `settings-store.ts` — `planEndpoints` state with get/set/remove methods (persisted in localStorage)
- `chat-sidebar.tsx` — "Subscription Plans" group in model selector, endpoint URL input (instead of API key), green "PLAN" badge, CLIProxyAPI setup link
- `api/chat/route.ts` & `api/generate-title/route.ts` — accept and forward `planEndpoint` parameter

## Why

Users who already pay for Claude Max, Gemini Ultra, or ChatGPT Plus/Pro subscriptions shouldn't need to also purchase separate API keys. None of these providers currently offer official third-party API access for consumer subscriptions, but the community-established workaround is to run CLI proxy tools (CLIProxyAPI, claude-max-api-proxy, etc.) that wrap the official CLIs and expose OpenAI-compatible endpoints. This PR integrates that pattern natively into the model selector.

## Test plan

- [x] Tests pass locally (`vitest` — 41/41 passing)
- [x] Tested manually — subscription plan models appear in model selector, endpoint configuration works, switching between plan/regular providers shows correct input types
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes (no new errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f293b7f-b947-415f-85ce-c2b24cf4c7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f293b7f-b947-415f-85ce-c2b24cf4c7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

