### PR TITLE
feat: add support for OpenAI gpt-5.4-mini and gpt-5.4-nano

### DIFF
--- a/src/lib/__tests__/model-registry.test.ts
+++ b/src/lib/__tests__/model-registry.test.ts
@@ -85,6 +85,15 @@ describe("PROVIDERS", () => {
       expect(p.envKey).toBeTruthy();
     }
   });
+
+  it("includes GPT-5.4 mini and nano for OpenAI", () => {
+    const openAI = findProvider("openai");
+    expect(openAI).toBeDefined();
+
+    const modelIds = new Set(openAI!.models.map((m) => m.id));
+    expect(modelIds.has("gpt-5.4-mini")).toBe(true);
+    expect(modelIds.has("gpt-5.4-nano")).toBe(true);
+  });
 });
 
 describe("ALL_MODELS", () => {

--- a/src/lib/model-registry.ts
+++ b/src/lib/model-registry.ts
@@ -39,6 +39,8 @@ export const PROVIDERS: ProviderInfo[] = [
     models: models("openai", "OpenAI", [
       ["gpt-5.4", "GPT-5.4"],
       ["gpt-5.4-pro", "GPT-5.4 Pro"],
+      ["gpt-5.4-mini", "GPT-5.4 Mini"],
+      ["gpt-5.4-nano", "GPT-5.4 Nano"],
       ["gpt-5.3-codex", "GPT-5.3 Codex"],
       ["gpt-5-codex", "GPT-5 Codex"],
       ["gpt-5", "GPT-5"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Added `gpt-5.4-mini` and `gpt-5.4-nano` to the OpenAI model registry so they appear in the in-app model selector.
- Added a unit test assertion that the OpenAI provider includes both new model IDs.

## Why

- The app should expose newly available OpenAI `gpt-5.4-mini` and `gpt-5.4-nano` models for BYOK users.

## Test plan

- [x] Tests pass locally
- [x] Tested manually
- Ran `npm test -- src/lib/__tests__/model-registry.test.ts src/lib/__tests__/create-model.test.ts`
- Ran `npm run lint -- src/lib/model-registry.ts src/lib/__tests__/model-registry.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67a3181b-a564-4b09-83e7-b7fd7bdabf8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67a3181b-a564-4b09-83e7-b7fd7bdabf8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

