### PR TITLE
docs: update CHANGELOG with recent merges (PRs #18, #19, #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ All notable changes to Infinite Monitor are documented here.
 
 ### Added
 
-- Infinite canvas dashboard replacing the fixed grid layout — pan, zoom, and freely position widgets
-- BYOK (Bring Your Own Key) model selection with 12 providers and 35+ models
-- Inline model picker and GitHub star button in the UI
+- Infinite canvas dashboard replacing the fixed grid layout — pan, zoom, and freely position widgets ([#18](https://github.com/homanp/infinite-monitor/pull/18))
+- Interactive minimap showing widget positions and current viewport ([#19](https://github.com/homanp/infinite-monitor/pull/19))
+- Portable dashboard templates bundled as static JSON files ([#20](https://github.com/homanp/infinite-monitor/pull/20))
+- Auto fit-to-view after applying a template ([#20](https://github.com/homanp/infinite-monitor/pull/20))
+- `deps.json` support in widget bootstrap to install extra packages for template widgets ([#20](https://github.com/homanp/infinite-monitor/pull/20))
+- BYOK (Bring Your Own Key) model selection with 12 providers and 35+ models ([#17](https://github.com/homanp/infinite-monitor/pull/17))
+- Inline model picker and GitHub star button in the UI ([#17](https://github.com/homanp/infinite-monitor/pull/17))
 - Vitest unit test suite with CI test job
 - Cursor BugBot CI workflow to auto-review new pull requests
-- GitHub CI workflows (lint, typecheck, test), issue templates, and PR template
-- Pre-commit hooks via lint-staged
+- GitHub CI workflows (lint, typecheck, test), issue templates, and PR template ([#10](https://github.com/homanp/infinite-monitor/pull/10))
+- Pre-commit hooks via lint-staged ([#10](https://github.com/homanp/infinite-monitor/pull/10))
 
 ### Changed
 
@@ -21,6 +25,12 @@ All notable changes to Infinite Monitor are documented here.
 
 ### Fixed
 
+- Canvas zoom-to-cursor by removing 200 k px margin trick that broke coordinate math at non-1× zoom levels ([#19](https://github.com/homanp/infinite-monitor/pull/19))
+- Canvas panning using `data-canvas-bg`/`data-widget` attributes instead of strict target check ([#19](https://github.com/homanp/infinite-monitor/pull/19))
+- Stale closure in wheel handler by reading viewport from ref ([#19](https://github.com/homanp/infinite-monitor/pull/19))
+- Dot-grid background now drawn via CSS `background-position` ([#19](https://github.com/homanp/infinite-monitor/pull/19))
+- Manually arranged canvas layouts saved per template (Crypto Trader, World Conflicts, Prediction Markets) ([#20](https://github.com/homanp/infinite-monitor/pull/20))
+- Skip non-`src` files in bootstrap to prevent cascade failure ([#20](https://github.com/homanp/infinite-monitor/pull/20))
 - Zustand hydration pattern restored for SSR compatibility
 - Lint and type errors resolved for CI compliance
 - CI lockfile compatibility across platforms (Node 20 with `npm install`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Update `CHANGELOG.md` to document changes from recently merged pull requests:

- **PR #18** — Infinite canvas dashboard (added PR link references to existing entries)
- **PR #19** — Canvas zoom-to-cursor fix, panning fix, minimap, dot-grid CSS background
- **PR #20** — Portable templates as static JSON, `deps.json` bootstrap support, auto fit-to-view, per-template canvas layouts

Also added PR link references to previously documented entries for PRs #10 and #17.

## Why

The CHANGELOG was last updated when PR #18 was merged. PRs #19 and #20 introduced significant fixes and features that should be documented in the Unreleased section.

## Test plan

- [x] Verified CHANGELOG formatting renders correctly
- No code changes — documentation only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9685014-2a52-4780-924e-1bebe95b00b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9685014-2a52-4780-924e-1bebe95b00b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

