### PR TITLE
Fix add menu dropdown items: uppercase with matching font size

### DIFF
--- a/src/components/add-menu.tsx
+++ b/src/components/add-menu.tsx
@@ -36,7 +36,7 @@ export function AddMenu() {
             setActiveWidget(id);
             scheduleSyncToServer();
           }}
-          className="gap-2 cursor-pointer"
+          className="gap-2 cursor-pointer text-xs uppercase tracking-wider"
         >
           <LayoutGrid className="h-4 w-4" />
           Widget
@@ -46,7 +46,7 @@ export function AddMenu() {
             addTextBlock();
             scheduleSyncToServer();
           }}
-          className="gap-2 cursor-pointer"
+          className="gap-2 cursor-pointer text-xs uppercase tracking-wider"
         >
           <Type className="h-4 w-4" />
           Text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Added `text-xs uppercase tracking-wider` classes to the "Widget" and "Text" dropdown menu items in the Add menu so they match the toolbar styling.

## Why

The dropdown menu items were using the default `text-sm` font size and mixed-case text, while the toolbar buttons and the dashboard picker dropdown items all use `text-xs uppercase tracking-wider`. This created a visual inconsistency.

## Test plan

- [x] Tests pass locally
- [x] Tested manually

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5db76a-c6bb-477d-ae82-63344cd61ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5db76a-c6bb-477d-ae82-63344cd61ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

