### PR TITLE
Add OG image with InfiniteMonitor logo on black background

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,22 @@ import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_BASE_URL ?? "https://infinitemonitor.com"
+  ),
   title: "Infinite Monitor",
   description: "An infinite dashboard, completely customizable by the user.",
+  openGraph: {
+    title: "Infinite Monitor",
+    description: "An infinite dashboard, completely customizable by the user.",
+    siteName: "Infinite Monitor",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Infinite Monitor",
+    description: "An infinite dashboard, completely customizable by the user.",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,54 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const alt = "Infinite Monitor";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  const fontData = await readFile(
+    join(process.cwd(), "node_modules/geist/dist/fonts/geist-mono/GeistMono-Medium.ttf")
+  );
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "#000000",
+          fontFamily: "GeistMono",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            fontSize: 64,
+            fontWeight: 500,
+            letterSpacing: "0.2em",
+            textTransform: "uppercase" as const,
+          }}
+        >
+          <span style={{ color: "#52525b" }}>Infinite</span>
+          <span style={{ color: "#d4d4d8" }}>Monitor</span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: "GeistMono",
+          data: fontData,
+          style: "normal",
+          weight: 500,
+        },
+      ],
+    }
+  );
+}

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,0 +1,54 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const alt = "Infinite Monitor";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  const fontData = await readFile(
+    join(process.cwd(), "node_modules/geist/dist/fonts/geist-mono/GeistMono-Medium.ttf")
+  );
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "#000000",
+          fontFamily: "GeistMono",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            fontSize: 64,
+            fontWeight: 500,
+            letterSpacing: "0.2em",
+            textTransform: "uppercase" as const,
+          }}
+        >
+          <span style={{ color: "#52525b" }}>Infinite</span>
+          <span style={{ color: "#d4d4d8" }}>Monitor</span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: "GeistMono",
+          data: fontData,
+          style: "normal",
+          weight: 500,
+        },
+      ],
+    }
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add Open Graph and Twitter card images for Infinite Monitor. The images render the "INFINITEMONITOR" logo text on a pure black background using the Geist Mono font, matching the app's header styling — "INFINITE" in dim zinc-600 and "MONITOR" in bright zinc-300, uppercase with wide letter spacing.

## Why

The app had no OG image or social card metadata. When shared on Twitter, Discord, Slack, etc., there was no preview image. This adds a clean, branded preview image that matches the app's visual identity.

## Test plan

- [x] Tests pass locally (`npm run lint` — 0 errors, `npm run build` — success)
- [x] Tested manually — dev server returns valid 1200×630 PNG at `/opengraph-image` and `/twitter-image`, and all OG/Twitter meta tags are correctly injected into the HTML
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98472c34-7172-41b7-8d1f-2f404aa7b581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98472c34-7172-41b7-8d1f-2f404aa7b581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

