### PR TITLE
docs: update CHANGELOG with recent additions (PRs #22–#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Infinite Monitor are documented here.
 
 ### Added
 
+- MCP (Model Context Protocol) server configuration with Cursor-style marketplace UI, per-server logos, and chat sidebar integration ([#40](https://github.com/homanp/infinite-monitor/pull/40))
+- New widget placement logic — widgets appear at the top of the canvas, shifting existing items down ([#41](https://github.com/homanp/infinite-monitor/pull/41))
+- OG image and Twitter card image with InfiniteMonitor logo on black background ([#42](https://github.com/homanp/infinite-monitor/pull/42))
+- Text block support for canvas titles and annotations ([#37](https://github.com/homanp/infinite-monitor/pull/37))
+- Unified "Add" dropdown menu replacing separate Add Widget and Add Text buttons ([#37](https://github.com/homanp/infinite-monitor/pull/37))
+- Custom web search tool with Brin security scanning for agent queries ([#22](https://github.com/homanp/infinite-monitor/pull/22))
+- Docker Compose deployment with Dockerfile and CI/CD pipeline ([#28](https://github.com/homanp/infinite-monitor/pull/28))
+- Caddy reverse proxy with auto HTTPS for infinitemonitor.com ([#28](https://github.com/homanp/infinite-monitor/pull/28))
+- Favicon and Apple touch icon ([#29](https://github.com/homanp/infinite-monitor/pull/29))
+- OpenAI GPT-5.4 mini and nano models ([#35](https://github.com/homanp/infinite-monitor/pull/35))
+- AGENTS.md with Cursor Cloud development environment instructions ([#32](https://github.com/homanp/infinite-monitor/pull/32))
 - Infinite canvas dashboard replacing the fixed grid layout — pan, zoom, and freely position widgets ([#18](https://github.com/homanp/infinite-monitor/pull/18))
 - Interactive minimap showing widget positions and current viewport ([#19](https://github.com/homanp/infinite-monitor/pull/19))
 - Portable dashboard templates bundled as static JSON files ([#20](https://github.com/homanp/infinite-monitor/pull/20))
@@ -14,17 +25,25 @@ All notable changes to Infinite Monitor are documented here.
 - BYOK (Bring Your Own Key) model selection with 12 providers and 35+ models ([#17](https://github.com/homanp/infinite-monitor/pull/17))
 - Inline model picker and GitHub star button in the UI ([#17](https://github.com/homanp/infinite-monitor/pull/17))
 - Vitest unit test suite with CI test job
-- Cursor BugBot CI workflow to auto-review new pull requests
 - GitHub CI workflows (lint, typecheck, test), issue templates, and PR template ([#10](https://github.com/homanp/infinite-monitor/pull/10))
 - Pre-commit hooks via lint-staged ([#10](https://github.com/homanp/infinite-monitor/pull/10))
 
 ### Changed
 
+- Entire widget header is now draggable, not just the drag icon ([#38](https://github.com/homanp/infinite-monitor/pull/38))
+- Add menu dropdown items use uppercase text with matching font size ([#39](https://github.com/homanp/infinite-monitor/pull/39))
+- MCP configuration UI redesigned to match Cursor's settings pattern ([#40](https://github.com/homanp/infinite-monitor/pull/40))
+- README trimmed from 244 to 136 lines ([#30](https://github.com/homanp/infinite-monitor/pull/30))
+- Removed BugBot CI workflow in favor of automatic reviews
 - Consolidated 9 agent tools down to 6 using bash-tool
 - Updated README tool list to reflect the 6-tool architecture
 
 ### Fixed
 
+- Client API keys now properly forwarded to AI providers ([#27](https://github.com/homanp/infinite-monitor/pull/27))
+- Next.js binds to all interfaces in Docker for container networking ([#27](https://github.com/homanp/infinite-monitor/pull/27))
+- Add button always visible in MCP marketplace list ([#40](https://github.com/homanp/infinite-monitor/pull/40))
+- Dead `isSafe` export removed; web search filter uses `.safe` property ([#22](https://github.com/homanp/infinite-monitor/pull/22))
 - Canvas zoom-to-cursor by removing 200 k px margin trick that broke coordinate math at non-1× zoom levels ([#19](https://github.com/homanp/infinite-monitor/pull/19))
 - Canvas panning using `data-canvas-bg`/`data-widget` attributes instead of strict target check ([#19](https://github.com/homanp/infinite-monitor/pull/19))
 - Stale closure in wheel handler by reading viewport from ref ([#19](https://github.com/homanp/infinite-monitor/pull/19))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Updates the `CHANGELOG.md` Unreleased section with all features, changes, and fixes merged since the last changelog update (PRs #22 through #42).

New entries cover:
- **Added**: MCP server configuration & marketplace UI (#40), new widget placement logic (#41), OG/Twitter card images (#42), text blocks for canvas (#37), unified Add dropdown (#37), web search with Brin security (#22), Docker Compose deployment & Caddy reverse proxy (#28), favicon (#29), GPT-5.4 models (#35), AGENTS.md (#32)
- **Changed**: Full-header widget dragging (#38), uppercase Add menu items (#39), MCP UI redesign (#40), README trim (#30), BugBot removal
- **Fixed**: API key forwarding (#27), Docker networking (#27), MCP Add button visibility (#40), dead isSafe export (#22)

## Why

The changelog was last updated through PRs #17–#20 and was missing documentation for 13+ merged pull requests.

## Test plan

- [x] Verified changelog renders correctly with proper Markdown formatting
- [x] All PR links point to valid pull request numbers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5763064a-5b88-4958-b949-76ad19c2292f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5763064a-5b88-4958-b949-76ad19c2292f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

