### PR TITLE
fix chat tool status visibility

### DIFF
--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -148,7 +148,7 @@ function ConversationMessages({
   streamingMsgId: string | null;
   activeAction: string | null;
 }) {
-  const showPlanningNextMoves = isStreaming && !activeAction;
+  const showPlanningNextMoves = isStreaming && !isReasoningStreaming && !activeAction;
 
   return (
     <>


### PR DESCRIPTION

## What

<!-- Brief description of changes -->

Keep transient tool actions visible long enough to render and show Planning next moves whenever streaming continues without an active tool call.


## Why

<!-- Why is this needed? -->

Fixes some transient issues with showing tool calls. 

## Test plan

- [x] Tests pass locally
- [x] Tested manually
