### PR TITLE
feat: add stable dashboard sharing with live session updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ DEEPINFRA_API_KEY=
 CEREBRAS_API_KEY=
 MOONSHOT_API_KEY=
 ALIBABA_API_KEY=
+
+# --- Share / Publish ---
+DURABLE_STREAM_BASE_URL=    # defaults to https://stream.tonbo.dev
+SHARE_ID_SECRET=            # secret for deriving stable share IDs

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -393,11 +393,19 @@ export async function POST(request: Request) {
         sent: boolean;
       } | null = null;
       let assistantText = "";
+      let assistantReasoning = "";
+      let reasoningStartedAt: number | null = null;
+      let reasoningDurationMs: number | null = null;
 
       try {
         for await (const part of result.fullStream) {
+          if (part.type !== "reasoning-delta" && reasoningStartedAt !== null && reasoningDurationMs === null) {
+            reasoningDurationMs = Date.now() - reasoningStartedAt;
+          }
           switch (part.type) {
             case "reasoning-delta":
+              if (reasoningStartedAt === null) reasoningStartedAt = Date.now();
+              assistantReasoning += part.text;
               send({ type: "reasoning-delta", text: part.text });
               break;
 
@@ -533,6 +541,14 @@ export async function POST(request: Request) {
                   toolName: resultToolName,
                 });
               }
+              if (traceRecorder) {
+                const effectiveDurationMs = reasoningDurationMs ?? (reasoningStartedAt ? Date.now() - reasoningStartedAt : undefined);
+                const interim: SharedChatMessage[] = [
+                  ...messages.map((m, i) => ({ id: `msg-${i}`, role: m.role, content: typeof m.content === "string" ? m.content : JSON.stringify(m.content) })),
+                  ...(assistantText || assistantReasoning ? [{ id: `msg-${messages.length}`, role: "assistant" as const, content: assistantText, ...(assistantReasoning ? { reasoning: assistantReasoning, ...(effectiveDurationMs ? { reasoningDurationMs: effectiveDurationMs } : {}) } : {}) }] : []),
+                ];
+                traceRecorder.flushMessages(interim);
+              }
               break;
             }
 
@@ -550,9 +566,10 @@ export async function POST(request: Request) {
 
         traceRecorder?.record("run-finished", "Run completed");
         if (traceRecorder && assistantText) {
+          const finalDurationMs = reasoningDurationMs ?? (reasoningStartedAt ? Date.now() - reasoningStartedAt : undefined);
           const chatMessages: SharedChatMessage[] = [
             ...messages.map((m, i) => ({ id: `msg-${i}`, role: m.role, content: typeof m.content === "string" ? m.content : JSON.stringify(m.content) })),
-            { id: `msg-${messages.length}`, role: "assistant" as const, content: assistantText },
+            { id: `msg-${messages.length}`, role: "assistant" as const, content: assistantText, ...(assistantReasoning ? { reasoning: assistantReasoning, ...(finalDurationMs ? { reasoningDurationMs: finalDurationMs } : {}) } : {}) },
           ];
           traceRecorder.flushMessages(chatMessages);
         }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -17,6 +17,9 @@ import {
 } from "@/db/widgets";
 import { webSearch, type SearchProvider } from "@/lib/web-search";
 import { scanUrls } from "@/lib/brin";
+import { nanoid } from "nanoid";
+import { maybeCreateTraceRecorder, publishDashboardStateForWidgetIfShared } from "@/lib/share-recorder";
+import type { SharedChatMessage } from "@/lib/share-types";
 
 interface McpServerPayload {
   name: string;
@@ -178,6 +181,9 @@ export async function POST(request: Request) {
     return Response.json({ error: "widgetId required" }, { status: 400 });
   }
 
+  const traceRecorder = await maybeCreateTraceRecorder(widgetId).catch(() => null);
+  traceRecorder?.startRun();
+
   const selectedModel = modelStr ?? "anthropic:claude-sonnet-4-6";
   const useAnthropic = isAnthropicModel(selectedModel);
 
@@ -219,7 +225,9 @@ export async function POST(request: Request) {
         await writeWidgetFile(widgetId, relative, content);
         if (relative === "src/App.tsx") {
           rebuildWidget(widgetId).catch(console.error);
+          publishDashboardStateForWidgetIfShared(widgetId).catch(() => {});
         }
+        traceRecorder?.record("file-written", `Wrote ${relative}`, { path: relative });
       }
     },
   };
@@ -384,6 +392,7 @@ export async function POST(request: Request) {
         accumulated: string;
         sent: boolean;
       } | null = null;
+      let assistantText = "";
 
       try {
         for await (const part of result.fullStream) {
@@ -393,6 +402,7 @@ export async function POST(request: Request) {
               break;
 
             case "text-delta":
+              assistantText += part.text;
               send({ type: "text-delta", text: part.text });
               break;
 
@@ -438,6 +448,10 @@ export async function POST(request: Request) {
               pendingToolInput = null;
               const input = part.input as Record<string, unknown> | undefined;
               const toolCallId = (part as { toolCallId?: string }).toolCallId;
+              const traceDetail = part.toolName === "writeFile" ? `Wrote ${input?.path ?? "file"}`
+                : part.toolName === "bash" ? `Ran ${String(input?.command ?? "").slice(0, 80)}`
+                : `Called ${part.toolName}`;
+              traceRecorder?.record("tool-call", traceDetail, { toolName: part.toolName });
               if (part.toolName === "writeFile") {
                 send({ type: "widget-file", path: input?.path, content: input?.content });
                 if (input?.path === "src/App.tsx") {
@@ -523,20 +537,32 @@ export async function POST(request: Request) {
             }
 
             case "abort":
+              traceRecorder?.record("run-abort", "Run aborted");
               send({ type: "abort" });
               break;
 
             case "error":
+              traceRecorder?.record("run-error", String(part.error));
               send({ type: "error", error: String(part.error) });
               break;
           }
         }
 
+        traceRecorder?.record("run-finished", "Run completed");
+        if (traceRecorder && assistantText) {
+          const chatMessages: SharedChatMessage[] = [
+            ...messages.map((m, i) => ({ id: `msg-${i}`, role: m.role, content: typeof m.content === "string" ? m.content : JSON.stringify(m.content) })),
+            { id: `msg-${messages.length}`, role: "assistant" as const, content: assistantText },
+          ];
+          traceRecorder.flushMessages(chatMessages);
+        }
         send({ type: "done" });
       } catch (err) {
+        traceRecorder?.record("run-error", String(err));
         send({ type: "error", error: String(err) });
       } finally {
         clearInterval(keepalive);
+        await traceRecorder?.flush();
         for (const client of mcpClients) {
           client.close().catch(() => {});
         }

--- a/src/app/api/dashboards/[id]/share/route.ts
+++ b/src/app/api/dashboards/[id]/share/route.ts
@@ -16,6 +16,7 @@ export async function POST(
   const streamId = getSessionStreamId(shareId);
   const ds = getDurableStreamClient();
 
+  await ds.ensureBucket(SHARE_BUCKET);
   await ds.createStream(SHARE_BUCKET, streamId);
 
   const source = loadDashboardPublishSource(id);

--- a/src/app/api/dashboards/[id]/share/route.ts
+++ b/src/app/api/dashboards/[id]/share/route.ts
@@ -12,24 +12,30 @@ export async function POST(
   const dashboard = getDashboard(id);
   if (!dashboard) return Response.json({ error: "Dashboard not found" }, { status: 404 });
 
-  const shareId = deriveShareId(id);
-  const streamId = getSessionStreamId(shareId);
-  const ds = getDurableStreamClient();
+  try {
+    const shareId = deriveShareId(id);
+    const streamId = getSessionStreamId(shareId);
+    const ds = getDurableStreamClient();
 
-  await ds.ensureBucket(SHARE_BUCKET);
-  await ds.createStream(SHARE_BUCKET, streamId);
+    await ds.ensureBucket(SHARE_BUCKET);
+    await ds.createStream(SHARE_BUCKET, streamId);
 
-  const source = loadDashboardPublishSource(id);
-  const state = buildDashboardSharedState(source, shareId);
-  await materializePublishedWidgets(state, { waitForBuild: true });
+    const source = loadDashboardPublishSource(id);
+    const state = buildDashboardSharedState(source, shareId);
+    await materializePublishedWidgets(state, { waitForBuild: true });
 
-  const event = { version: "v1" as const, kind: "dashboard.state" as const, shareId, dashboardId: id, at: state.updatedAt, stateHash: "", state };
-  await ds.appendJson(SHARE_BUCKET, streamId, event);
+    const event = { version: "v1" as const, kind: "dashboard.state" as const, shareId, dashboardId: id, at: state.updatedAt, stateHash: "", state };
+    await ds.appendJson(SHARE_BUCKET, streamId, event);
 
-  const h = await headers();
-  const host = h.get("host") ?? "localhost:3000";
-  const protocol = host.startsWith("localhost") ? "http" : "https";
-  const shareUrl = `${protocol}://${host}/share/${shareId}`;
+    const h = await headers();
+    const host = h.get("host") ?? "localhost:3000";
+    const protocol = host.startsWith("localhost") ? "http" : "https";
+    const shareUrl = `${protocol}://${host}/share/${shareId}`;
 
-  return Response.json({ dashboardId: id, shareId, shareUrl, updatedAt: state.updatedAt });
+    return Response.json({ dashboardId: id, shareId, shareUrl, updatedAt: state.updatedAt });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Share failed";
+    console.error(`[share] dashboard=${id}:`, err);
+    return Response.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/app/api/dashboards/[id]/share/route.ts
+++ b/src/app/api/dashboards/[id]/share/route.ts
@@ -1,0 +1,34 @@
+import { getDashboard } from "@/db/widgets";
+import { deriveShareId, getSessionStreamId, SHARE_BUCKET } from "@/lib/share";
+import { getDurableStreamClient } from "@/lib/durable-stream";
+import { loadDashboardPublishSource, buildDashboardSharedState, materializePublishedWidgets } from "@/lib/share-projection";
+import { headers } from "next/headers";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const dashboard = getDashboard(id);
+  if (!dashboard) return Response.json({ error: "Dashboard not found" }, { status: 404 });
+
+  const shareId = deriveShareId(id);
+  const streamId = getSessionStreamId(shareId);
+  const ds = getDurableStreamClient();
+
+  await ds.createStream(SHARE_BUCKET, streamId);
+
+  const source = loadDashboardPublishSource(id);
+  const state = buildDashboardSharedState(source, shareId);
+  await materializePublishedWidgets(state, { waitForBuild: true });
+
+  const event = { version: "v1" as const, kind: "dashboard.state" as const, shareId, dashboardId: id, at: state.updatedAt, stateHash: "", state };
+  await ds.appendJson(SHARE_BUCKET, streamId, event);
+
+  const h = await headers();
+  const host = h.get("host") ?? "localhost:3000";
+  const protocol = host.startsWith("localhost") ? "http" : "https";
+  const shareUrl = `${protocol}://${host}/share/${shareId}`;
+
+  return Response.json({ dashboardId: id, shareId, shareUrl, updatedAt: state.updatedAt });
+}

--- a/src/app/api/share/[shareId]/bootstrap/route.ts
+++ b/src/app/api/share/[shareId]/bootstrap/route.ts
@@ -1,0 +1,54 @@
+import { getDurableStreamClient, getDurableStreamBaseUrl } from "@/lib/durable-stream";
+import { getSessionStreamId, SHARE_BUCKET } from "@/lib/share";
+import { materializePublishedWidgets } from "@/lib/share-projection";
+import {
+  buildEmptySharedSessionSnapshot,
+  SharedSessionEventV1Schema,
+  SharedSessionSnapshotV1Schema,
+  applySharedSessionEvent,
+  type SharedSessionSnapshotV1,
+} from "@/lib/share-types";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ shareId: string }> },
+) {
+  const { shareId } = await params;
+  const streamId = getSessionStreamId(shareId);
+  const ds = getDurableStreamClient();
+
+  const bootstrap = await ds.bootstrap(SHARE_BUCKET, streamId);
+  if (!bootstrap) {
+    return Response.json({ error: "Share not found" }, { status: 404 });
+  }
+
+  const [snapshotPart, ...updateParts] = bootstrap.parts;
+  let snapshot: SharedSessionSnapshotV1 = buildEmptySharedSessionSnapshot(shareId);
+
+  if (snapshotPart?.body.trim()) {
+    const parsed = SharedSessionSnapshotV1Schema.safeParse(JSON.parse(snapshotPart.body));
+    if (parsed.success) snapshot = { ...parsed.data, chats: parsed.data.chats ?? [] };
+  }
+
+  for (const part of updateParts) {
+    if (!part.body.trim()) continue;
+    const parsed = SharedSessionEventV1Schema.safeParse(JSON.parse(part.body));
+    if (parsed.success) snapshot = applySharedSessionEvent(snapshot, parsed.data);
+  }
+
+  if (!snapshot.dashboard) {
+    return Response.json({ error: "No dashboard state" }, { status: 404 });
+  }
+
+  // Materialize published widgets into local SQLite + trigger builds
+  // so this server can serve widget iframes even if it's not the author's server
+  await materializePublishedWidgets(snapshot.dashboard, { waitForBuild: false });
+
+  const liveUrl = `${getDurableStreamBaseUrl()}/ds/${SHARE_BUCKET}/${streamId}`;
+
+  return Response.json({
+    snapshot,
+    nextOffset: bootstrap.nextOffset ?? "now",
+    liveUrl,
+  });
+}

--- a/src/app/api/share/[shareId]/bootstrap/route.ts
+++ b/src/app/api/share/[shareId]/bootstrap/route.ts
@@ -40,6 +40,8 @@ export async function GET(
     return Response.json({ error: "No dashboard state" }, { status: 404 });
   }
 
+  console.log("[bootstrap] widgets:", snapshot.dashboard.widgets.map((w) => ({ id: w.publishedWidgetId, layout: w.layout, title: w.title })));
+
   // Materialize published widgets into local SQLite + trigger builds
   // so this server can serve widget iframes even if it's not the author's server
   await materializePublishedWidgets(snapshot.dashboard, { waitForBuild: false });

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,4 +1,38 @@
 import { syncState, getFullState } from "@/db/widgets";
+import { deriveShareId, getSessionStreamId, SHARE_BUCKET } from "@/lib/share";
+import { getDurableStreamClient } from "@/lib/durable-stream";
+import { loadDashboardPublishSource, buildDashboardSharedState, buildDashboardStateContentHash, materializePublishedWidgets } from "@/lib/share-projection";
+import type { SyncPayload } from "@/lib/sync-db";
+
+const lastKnownHashes = new Map<string, string>();
+
+async function publishIfShared(dashboardId: string) {
+  const shareId = deriveShareId(dashboardId);
+  const streamId = getSessionStreamId(shareId);
+  const ds = getDurableStreamClient();
+
+  const head = await ds.head(SHARE_BUCKET, streamId);
+  if (!head.exists) return;
+
+  const source = loadDashboardPublishSource(dashboardId);
+  const state = buildDashboardSharedState(source, shareId);
+  const hash = buildDashboardStateContentHash(state);
+  if (lastKnownHashes.get(shareId) === hash) return;
+  lastKnownHashes.set(shareId, hash);
+
+  await materializePublishedWidgets(state, { waitForBuild: false });
+
+  const event = {
+    version: "v1" as const,
+    kind: "dashboard.state" as const,
+    shareId,
+    dashboardId,
+    at: state.updatedAt,
+    stateHash: hash,
+    state,
+  };
+  await ds.appendJson(SHARE_BUCKET, streamId, event);
+}
 
 export async function GET() {
   const state = getFullState();
@@ -6,26 +40,14 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const body = await request.json();
-  const { dashboards, widgets, textBlocks } = body as {
-    dashboards: Array<{ id: string; title: string; widgetIds: string[]; textBlockIds?: string[]; createdAt: number }>;
-    widgets: Array<{
-      id: string;
-      title: string;
-      description: string;
-      code: string | null;
-      files?: Record<string, string>;
-      layout: unknown;
-      messages: unknown[];
-    }>;
-    textBlocks?: Array<{
-      id: string;
-      text: string;
-      fontSize: number;
-      layout: unknown;
-    }>;
-  };
+  const body = (await request.json()) as SyncPayload;
+  syncState({ dashboards: body.dashboards ?? [], widgets: body.widgets ?? [], textBlocks: body.textBlocks ?? [] });
 
-  syncState({ dashboards: dashboards ?? [], widgets: widgets ?? [], textBlocks: textBlocks ?? [] });
+  for (const dashboardId of body.dirtyDashboardIds ?? []) {
+    publishIfShared(dashboardId).catch((err) =>
+      console.error(`[sync] Failed to publish dashboard ${dashboardId}:`, err),
+    );
+  }
+
   return Response.json({ ok: true });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,69 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { DashboardGrid } from "@/components/dashboard-grid";
 import { ChatSidebar } from "@/components/chat-sidebar";
 import { AddMenu } from "@/components/add-menu";
 import { DashboardPicker } from "@/components/dashboard-picker";
 import { ShareDashboardButton } from "@/components/share-dashboard-button";
-import { ScrambleText } from "@/components/scramble-text";
-import { Star } from "lucide-react";
-import { buttonVariants } from "@/components/ui/button";
-
-function useGitHubStars() {
-  const [stars, setStars] = useState<number | null>(null);
-  useEffect(() => {
-    fetch("https://api.github.com/repos/homanp/infinite-monitor")
-      .then((r) => r.ok ? r.json() : null)
-      .then((data) => {
-        if (data?.stargazers_count != null) setStars(data.stargazers_count);
-      })
-      .catch(() => {});
-  }, []);
-  return stars;
-}
+import { AppHeader } from "@/components/app-header";
 
 export default function Home() {
-  const stars = useGitHubStars();
-  const infiniteLen = "Infinite".length;
-
   return (
     <div className="flex h-screen overflow-hidden bg-zinc-900">
       <div className="flex flex-col flex-1 min-w-0">
-        <header className="flex items-center justify-between gap-4 px-5 py-3">
-          <h1 className="min-w-0 shrink-0 text-sm font-medium uppercase tracking-[0.2em]">
-            <ScrambleText
-              text="InfiniteMonitor"
-              charClassName={(i) =>
-                i < infiniteLen ? "text-zinc-600" : "text-zinc-300"
-              }
-            />
-          </h1>
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-            <a
-              href="https://github.com/homanp/infinite-monitor"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={buttonVariants({
-                size: "sm",
-                className:
-                  "gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 hover:bg-zinc-700 uppercase tracking-wider !text-xs",
-              })}
-            >
-              <Star className="h-3.5 w-3.5" />
-              GitHub
-              {stars !== null && (
-                <>
-                  <span className="text-zinc-600">·</span>
-                  <span>{stars.toLocaleString()}</span>
-                </>
-              )}
-            </a>
-            <DashboardPicker />
-            <ShareDashboardButton />
-            <AddMenu />
-          </div>
-        </header>
+        <AppHeader>
+          <DashboardPicker />
+          <ShareDashboardButton />
+          <AddMenu />
+        </AppHeader>
         <DashboardGrid />
       </div>
       <ChatSidebar />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { DashboardGrid } from "@/components/dashboard-grid";
 import { ChatSidebar } from "@/components/chat-sidebar";
 import { AddMenu } from "@/components/add-menu";
 import { DashboardPicker } from "@/components/dashboard-picker";
+import { ShareDashboardButton } from "@/components/share-dashboard-button";
 import { ScrambleText } from "@/components/scramble-text";
 import { Star } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
@@ -59,6 +60,7 @@ export default function Home() {
               )}
             </a>
             <DashboardPicker />
+            <ShareDashboardButton />
             <AddMenu />
           </div>
         </header>

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -1,10 +1,14 @@
-import { LiveSharedDashboardView } from "@/components/live-shared-dashboard-view";
+"use client";
 
-export default async function SharePage({
-  params,
-}: {
-  params: Promise<{ shareId: string }>;
-}) {
-  const { shareId } = await params;
+import dynamic from "next/dynamic";
+import { useParams } from "next/navigation";
+
+const LiveSharedDashboardView = dynamic(
+  () => import("@/components/live-shared-dashboard-view").then((m) => m.LiveSharedDashboardView),
+  { ssr: false },
+);
+
+export default function SharePage() {
+  const { shareId } = useParams<{ shareId: string }>();
   return <LiveSharedDashboardView shareId={shareId} />;
 }

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -1,0 +1,10 @@
+import { LiveSharedDashboardView } from "@/components/live-shared-dashboard-view";
+
+export default async function SharePage({
+  params,
+}: {
+  params: Promise<{ shareId: string }>;
+}) {
+  const { shareId } = await params;
+  return <LiveSharedDashboardView shareId={shareId} />;
+}

--- a/src/components/add-menu.tsx
+++ b/src/components/add-menu.tsx
@@ -15,6 +15,7 @@ export function AddMenu() {
   const addWidget = useWidgetStore((s) => s.addWidget);
   const setActiveWidget = useWidgetStore((s) => s.setActiveWidget);
   const addTextBlock = useWidgetStore((s) => s.addTextBlock);
+  const activeDashboardId = useWidgetStore((s) => s.activeDashboardId);
 
   return (
     <DropdownMenu>
@@ -34,7 +35,7 @@ export function AddMenu() {
           onClick={() => {
             const id = addWidget();
             setActiveWidget(id);
-            scheduleSyncToServer();
+            scheduleSyncToServer({ dirtyDashboardIds: activeDashboardId ? [activeDashboardId] : [] });
           }}
           className="gap-2 cursor-pointer text-xs uppercase tracking-wider"
         >
@@ -44,7 +45,7 @@ export function AddMenu() {
         <DropdownMenuItem
           onClick={() => {
             addTextBlock();
-            scheduleSyncToServer();
+            scheduleSyncToServer({ dirtyDashboardIds: activeDashboardId ? [activeDashboardId] : [] });
           }}
           className="gap-2 cursor-pointer text-xs uppercase tracking-wider"
         >

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Star } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { ScrambleText } from "@/components/scramble-text";
+
+function useGitHubStars() {
+  const [stars, setStars] = useState<number | null>(null);
+  useEffect(() => {
+    fetch("https://api.github.com/repos/homanp/infinite-monitor")
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (data?.stargazers_count != null) setStars(data.stargazers_count);
+      })
+      .catch(() => {});
+  }, []);
+  return stars;
+}
+
+export function AppHeader({ children }: { children?: React.ReactNode }) {
+  const stars = useGitHubStars();
+  const infiniteLen = "Infinite".length;
+
+  return (
+    <header className="flex items-center justify-between gap-4 px-5 py-3">
+      <h1 className="min-w-0 shrink-0 text-sm font-medium uppercase tracking-[0.2em]">
+        <ScrambleText
+          text="InfiniteMonitor"
+          charClassName={(i) =>
+            i < infiniteLen ? "text-zinc-600" : "text-zinc-300"
+          }
+        />
+      </h1>
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+        <a
+          href="https://github.com/homanp/infinite-monitor"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonVariants({
+            size: "sm",
+            className:
+              "gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 hover:bg-zinc-700 uppercase tracking-wider !text-xs",
+          })}
+        >
+          <Star className="h-3.5 w-3.5" />
+          GitHub
+          {stars !== null && (
+            <>
+              <span className="text-zinc-600">·</span>
+              <span>{stars.toLocaleString()}</span>
+            </>
+          )}
+        </a>
+        {children}
+      </div>
+    </header>
+  );
+}

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -135,7 +135,7 @@ function ReasoningBlock({
   );
 }
 
-function ConversationMessages({
+export function ConversationMessages({
   messages,
   isStreaming,
   isReasoningStreaming,

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -135,7 +135,7 @@ function ReasoningBlock({
   );
 }
 
-export function ConversationMessages({
+function ConversationMessages({
   messages,
   isStreaming,
   isReasoningStreaming,

--- a/src/components/dashboard-grid.tsx
+++ b/src/components/dashboard-grid.tsx
@@ -85,7 +85,7 @@ function TemplateGallery({ containerRef }: { containerRef: React.RefObject<HTMLD
       setViewport(activeDashboardId, { panX: fitPanX, panY: fitPanY, zoom: fitZoom });
     }
 
-    scheduleSyncToServer();
+    scheduleSyncToServer({ dirtyDashboardIds: activeDashboardId ? [activeDashboardId] : [] });
     setApplying(null);
   };
 
@@ -223,32 +223,33 @@ export function DashboardGrid() {
   const handleLayoutChange = useCallback(
     (widgetId: string, layout: CanvasLayout) => {
       updateWidgetLayout(widgetId, layout);
+      scheduleSyncToServer({ urgency: "interactive", dirtyDashboardIds: activeDashboardId ? [activeDashboardId] : [] });
     },
-    [updateWidgetLayout]
+    [updateWidgetLayout, activeDashboardId]
   );
 
   const handleTextBlockTextChange = useCallback(
     (id: string, text: string) => {
       updateTextBlock(id, { text });
-      scheduleSyncToServer();
+      scheduleSyncToServer({ dirtyDashboardIds: activeDashboardId ? [activeDashboardId] : [] });
     },
-    [updateTextBlock]
+    [updateTextBlock, activeDashboardId]
   );
 
   const handleTextBlockFontSizeChange = useCallback(
     (id: string, fontSize: number) => {
       updateTextBlock(id, { fontSize });
-      scheduleSyncToServer();
+      scheduleSyncToServer({ dirtyDashboardIds: activeDashboardId ? [activeDashboardId] : [] });
     },
-    [updateTextBlock]
+    [updateTextBlock, activeDashboardId]
   );
 
   const handleTextBlockLayoutChange = useCallback(
     (id: string, layout: CanvasLayout) => {
       updateTextBlockLayout(id, layout);
-      scheduleSyncToServer();
+      scheduleSyncToServer({ dirtyDashboardIds: activeDashboardId ? [activeDashboardId] : [] });
     },
-    [updateTextBlockLayout]
+    [updateTextBlockLayout, activeDashboardId]
   );
 
   const handleRemoveTextBlock = useCallback(

--- a/src/components/dashboard-picker.tsx
+++ b/src/components/dashboard-picker.tsx
@@ -1,16 +1,23 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { ChevronDown, Plus, Pencil, Check, Trash2, LayoutDashboard } from "lucide-react";
+import { useRouter, usePathname } from "next/navigation";
+import { ChevronDown, Plus, Pencil, Check, Trash2, LayoutDashboard, Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { useWidgetStore } from "@/store/widget-store";
 import { scheduleSyncToServer } from "@/lib/sync-db";
 
-export function DashboardPicker() {
+export function DashboardPicker({ currentShareTitle }: { currentShareTitle?: string } = {}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const isOnSharePage = pathname.startsWith("/share/");
+
   const dashboards = useWidgetStore((s) => s.dashboards);
   const activeDashboardId = useWidgetStore((s) => s.activeDashboardId);
+  const savedShares = useWidgetStore((s) => s.savedShares);
+  const removeShare = useWidgetStore((s) => s.removeShare);
   const addDashboard = useWidgetStore((s) => s.addDashboard);
   const renameDashboard = useWidgetStore((s) => s.renameDashboard);
   const removeDashboard = useWidgetStore((s) => s.removeDashboard);
@@ -58,8 +65,9 @@ export function DashboardPicker() {
     setOpen(false);
     setEditingId(null);
     setCreatingNew(false);
-    scheduleSyncToServer();
-  }, [setActiveDashboard]);
+    scheduleSyncToServer({ dirtyDashboardIds: [id] });
+    if (isOnSharePage) router.push("/");
+  }, [setActiveDashboard, isOnSharePage, router]);
 
   const handleStartEdit = useCallback((e: React.MouseEvent, id: string, title: string) => {
     e.stopPropagation();
@@ -70,7 +78,7 @@ export function DashboardPicker() {
   const handleFinishEdit = useCallback(() => {
     if (editingId && editValue.trim()) {
       renameDashboard(editingId, editValue.trim());
-      scheduleSyncToServer();
+      scheduleSyncToServer({ dirtyDashboardIds: [editingId] });
     }
     setEditingId(null);
   }, [editingId, editValue, renameDashboard]);
@@ -81,8 +89,9 @@ export function DashboardPicker() {
     setActiveDashboard(id);
     setCreatingNew(false);
     setNewName("");
-    scheduleSyncToServer();
-  }, [newName, addDashboard, setActiveDashboard]);
+    scheduleSyncToServer({ dirtyDashboardIds: [id] });
+    if (isOnSharePage) router.push("/");
+  }, [newName, addDashboard, setActiveDashboard, isOnSharePage, router]);
 
   const handleDelete = useCallback((e: React.MouseEvent, id: string) => {
     e.stopPropagation();
@@ -113,8 +122,6 @@ export function DashboardPicker() {
     }).catch(() => {});
   }, [removeDashboard, dashboards]);
 
-  if (dashboards.length === 0) return null;
-
   return (
     <div className="relative" ref={dropdownRef}>
       <Button
@@ -127,7 +134,7 @@ export function DashboardPicker() {
       >
         <LayoutDashboard className="h-4 w-4" />
         <span className="max-w-[140px] truncate">
-          {activeDashboard?.title ?? "Dashboard"}
+          {isOnSharePage ? (currentShareTitle ?? "Shared") : (activeDashboard?.title ?? "Dashboard")}
         </span>
         <ChevronDown className={cn("h-3 w-3 transition-transform", open && "rotate-180")} />
       </Button>
@@ -190,6 +197,35 @@ export function DashboardPicker() {
               </div>
             ))}
           </div>
+
+          {savedShares.length > 0 && (
+            <div className="border-t border-zinc-700 py-1">
+              {savedShares.map((share) => (
+                <div
+                  key={share.shareId}
+                  onClick={() => { setOpen(false); router.push(`/share/${share.shareId}`); }}
+                  className={cn(
+                    "flex items-center gap-2 px-3 py-1.5 text-xs uppercase tracking-wider cursor-pointer transition-colors",
+                    isOnSharePage && pathname === `/share/${share.shareId}`
+                      ? "text-zinc-100 bg-zinc-700/50"
+                      : "text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/30"
+                  )}
+                >
+                  <Share2 className="h-3 w-3 shrink-0 text-zinc-500" />
+                  <span className="flex-1 truncate">{share.title}</span>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); removeShare(share.shareId); }}
+                    className="text-zinc-500 hover:text-red-400 shrink-0"
+                    style={{ opacity: 0 }}
+                    onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.opacity = "1"; }}
+                    onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.opacity = "0"; }}
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
 
           <div className="border-t border-zinc-700">
             {creatingNew ? (

--- a/src/components/live-shared-dashboard-view.tsx
+++ b/src/components/live-shared-dashboard-view.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, Eye, LoaderCircle } from "lucide-react";
+import { AppHeader } from "@/components/app-header";
+import { SharedDashboardView } from "@/components/shared-dashboard-view";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  applySharedSessionEvent,
+  buildEmptySharedSessionSnapshot,
+  SharedSessionEventV1Schema,
+  type SharedSessionSnapshotV1,
+} from "@/lib/share-types";
+import { DashboardPicker } from "@/components/dashboard-picker";
+import { useWidgetStore } from "@/store/widget-store";
+import { cn } from "@/lib/utils";
+
+interface BootstrapPayload {
+  snapshot: SharedSessionSnapshotV1;
+  nextOffset?: string | null;
+  liveUrl?: string;
+}
+
+export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
+  const saveShare = useWidgetStore((s) => s.saveShare);
+
+  const [snapshot, setSnapshot] = useState<SharedSessionSnapshotV1 | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [liveError, setLiveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let es: EventSource | null = null;
+    let reconnectTimer: number | null = null;
+    let nextOffset = "now";
+    let liveUrl = "";
+
+    const applyEvent = (raw: unknown) => {
+      const candidates = Array.isArray(raw) ? raw : [raw];
+      for (const c of candidates) {
+        const parsed = SharedSessionEventV1Schema.safeParse(c);
+        if (!parsed.success) continue;
+        setSnapshot((prev) => {
+          const base = prev ?? buildEmptySharedSessionSnapshot(shareId);
+          return applySharedSessionEvent(base, parsed.data);
+        });
+        setLiveError(null);
+      }
+    };
+
+    const connectLive = (url: string, offset: string) => {
+      if (cancelled) return;
+      liveUrl = url;
+      nextOffset = offset;
+      es?.close();
+
+      es = new EventSource(`${url}?offset=${encodeURIComponent(offset)}&live=sse`);
+
+      es.addEventListener("data", (e) => {
+        try { applyEvent(JSON.parse((e as MessageEvent<string>).data)); } catch {}
+      });
+
+      es.addEventListener("control", (e) => {
+        try {
+          const ctrl = JSON.parse((e as MessageEvent<string>).data) as Record<string, unknown>;
+          if (typeof ctrl.streamNextOffset === "string") {
+            nextOffset = ctrl.streamNextOffset;
+            setLiveError(null);
+          }
+        } catch {}
+      });
+
+      es.onerror = () => {
+        if (cancelled) return;
+        es?.close();
+        es = null;
+        setLiveError("Connection interrupted");
+        if (reconnectTimer !== null) return;
+        reconnectTimer = window.setTimeout(() => {
+          reconnectTimer = null;
+          connectLive(liveUrl, nextOffset);
+        }, 1500);
+      };
+    };
+
+    const bootstrap = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/share/${shareId}/bootstrap`);
+        const data = await res.json().catch(() => null);
+        if (!res.ok) throw new Error(data?.error ?? `Status ${res.status}`);
+        if (cancelled) return;
+
+        const payload = data as BootstrapPayload;
+        setSnapshot(payload.snapshot);
+        if (payload.snapshot.dashboard?.title) {
+          saveShare(shareId, payload.snapshot.dashboard.title);
+        }
+
+        if (payload.liveUrl) {
+          connectLive(payload.liveUrl, payload.nextOffset ?? "now");
+        }
+      } catch (err) {
+        if (!cancelled) { setError(err instanceof Error ? err.message : String(err)); setSnapshot(null); }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void bootstrap();
+
+    return () => {
+      cancelled = true;
+      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer);
+      es?.close();
+    };
+  }, [shareId]);
+
+  const chipCn = buttonVariants({
+    size: "sm",
+    className: "gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 uppercase tracking-wider !text-xs pointer-events-none",
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
+        <AppHeader><DashboardPicker currentShareTitle={snapshot?.dashboard?.title} /></AppHeader>
+        <div className="flex flex-1 items-center justify-center gap-2 text-sm text-zinc-500"><LoaderCircle className="h-4 w-4 animate-spin" />Loading…</div>
+      </div>
+    );
+  }
+
+  if (error || !snapshot?.dashboard) {
+    return (
+      <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
+        <AppHeader><DashboardPicker currentShareTitle={snapshot?.dashboard?.title} /></AppHeader>
+        <div className="flex flex-1 items-center justify-center px-6">
+          <div className="max-w-md border border-zinc-800 bg-zinc-900/60 p-6 text-center">
+            <AlertTriangle className="mx-auto h-5 w-5 text-amber-300" />
+            <h1 className="mt-3 text-sm uppercase tracking-[0.18em] text-zinc-100">Shared session unavailable</h1>
+            {error && <div className="mt-4 break-words text-xs text-zinc-500">{error}</div>}
+            <div className="mt-4 break-all text-[11px] uppercase tracking-[0.16em] text-zinc-600">{shareId}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
+      <AppHeader>
+        <DashboardPicker currentShareTitle={snapshot?.dashboard?.title} />
+        <div className={cn(chipCn, liveError && "border-amber-500/30 bg-amber-500/10 text-amber-100")}>
+          <Eye className="h-3.5 w-3.5" />{liveError ? "Reconnecting" : "Live sync"}
+        </div>
+      </AppHeader>
+      <SharedDashboardView snapshot={snapshot} liveError={liveError} />
+    </div>
+  );
+}

--- a/src/components/live-shared-dashboard-view.tsx
+++ b/src/components/live-shared-dashboard-view.tsx
@@ -15,22 +15,15 @@ import { DashboardPicker } from "@/components/dashboard-picker";
 import { useWidgetStore } from "@/store/widget-store";
 import { cn } from "@/lib/utils";
 
-interface BootstrapPayload {
-  snapshot: SharedSessionSnapshotV1;
-  nextOffset?: string | null;
-  liveUrl?: string;
-}
-
 export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
   const saveShare = useWidgetStore((s) => s.saveShare);
-
   const [mounted, setMounted] = useState(false);
   const [snapshot, setSnapshot] = useState<SharedSessionSnapshotV1 | null>(null);
   const [loading, setLoading] = useState(true);
-
-  useEffect(() => { setMounted(true); }, []);
   const [error, setError] = useState<string | null>(null);
   const [liveError, setLiveError] = useState<string | null>(null);
+
+  useEffect(() => { setMounted(true); }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -40,134 +33,68 @@ export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
     let liveUrl = "";
 
     const applyEvent = (raw: unknown) => {
-      const candidates = Array.isArray(raw) ? raw : [raw];
-      for (const c of candidates) {
+      for (const c of Array.isArray(raw) ? raw : [raw]) {
         const parsed = SharedSessionEventV1Schema.safeParse(c);
-        if (!parsed.success) continue;
-        setSnapshot((prev) => {
-          const base = prev ?? buildEmptySharedSessionSnapshot(shareId);
-          return applySharedSessionEvent(base, parsed.data);
-        });
-        setLiveError(null);
+        if (parsed.success) {
+          setSnapshot((prev) => applySharedSessionEvent(prev ?? buildEmptySharedSessionSnapshot(shareId), parsed.data));
+          setLiveError(null);
+        }
       }
     };
 
     const connectLive = (url: string, offset: string) => {
       if (cancelled) return;
-      liveUrl = url;
-      nextOffset = offset;
+      liveUrl = url; nextOffset = offset;
       es?.close();
-
       es = new EventSource(`${url}?offset=${encodeURIComponent(offset)}&live=sse`);
-
-      es.addEventListener("data", (e) => {
-        try { applyEvent(JSON.parse((e as MessageEvent<string>).data)); } catch {}
-      });
-
-      es.addEventListener("control", (e) => {
-        try {
-          const ctrl = JSON.parse((e as MessageEvent<string>).data) as Record<string, unknown>;
-          if (typeof ctrl.streamNextOffset === "string") {
-            nextOffset = ctrl.streamNextOffset;
-            setLiveError(null);
-          }
-        } catch {}
-      });
-
-      es.onerror = () => {
-        if (cancelled) return;
-        es?.close();
-        es = null;
-        setLiveError("Connection interrupted");
-        if (reconnectTimer !== null) return;
-        reconnectTimer = window.setTimeout(() => {
-          reconnectTimer = null;
-          connectLive(liveUrl, nextOffset);
-        }, 1500);
-      };
+      es.addEventListener("data", (e) => { try { applyEvent(JSON.parse((e as MessageEvent<string>).data)); } catch {} });
+      es.addEventListener("control", (e) => { try { const c = JSON.parse((e as MessageEvent<string>).data); if (typeof c.streamNextOffset === "string") { nextOffset = c.streamNextOffset; setLiveError(null); } } catch {} });
+      es.onerror = () => { if (cancelled) return; es?.close(); es = null; setLiveError("Connection interrupted"); if (reconnectTimer === null) reconnectTimer = window.setTimeout(() => { reconnectTimer = null; connectLive(liveUrl, nextOffset); }, 1500); };
     };
 
-    const bootstrap = async () => {
-      setLoading(true);
-      setError(null);
+    (async () => {
+      setLoading(true); setError(null);
       try {
         const res = await fetch(`/api/share/${shareId}/bootstrap`);
         const data = await res.json().catch(() => null);
         if (!res.ok) throw new Error(data?.error ?? `Status ${res.status}`);
         if (cancelled) return;
+        setSnapshot(data.snapshot);
+        if (data.snapshot.dashboard?.title) saveShare(shareId, data.snapshot.dashboard.title);
+        if (data.liveUrl) connectLive(data.liveUrl, data.nextOffset ?? "now");
+      } catch (err) { if (!cancelled) { setError(err instanceof Error ? err.message : String(err)); setSnapshot(null); } }
+      finally { if (!cancelled) setLoading(false); }
+    })();
 
-        const payload = data as BootstrapPayload;
-        setSnapshot(payload.snapshot);
-        if (payload.snapshot.dashboard?.title) {
-          saveShare(shareId, payload.snapshot.dashboard.title);
-        }
+    return () => { cancelled = true; if (reconnectTimer !== null) window.clearTimeout(reconnectTimer); es?.close(); };
+  }, [shareId, saveShare]);
 
-        if (payload.liveUrl) {
-          connectLive(payload.liveUrl, payload.nextOffset ?? "now");
-        }
-      } catch (err) {
-        if (!cancelled) { setError(err instanceof Error ? err.message : String(err)); setSnapshot(null); }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-
-    void bootstrap();
-
-    return () => {
-      cancelled = true;
-      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer);
-      es?.close();
-    };
-  }, [shareId]);
-
-  const chipCn = buttonVariants({
-    size: "sm",
-    className: "gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 uppercase tracking-wider !text-xs pointer-events-none",
-  });
-
-  const shareTitle = snapshot?.dashboard?.title;
+  const chipCn = buttonVariants({ size: "sm", className: "gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 uppercase tracking-wider !text-xs pointer-events-none" });
+  const ok = mounted && !loading && !liveError && !error;
   const statusLabel = !mounted || loading ? "Connecting" : liveError ? "Reconnecting" : error ? "Offline" : "Live sync";
-  const statusAlert = !mounted || loading || liveError || error;
+  const ready = mounted && !loading && snapshot?.dashboard;
 
-  const header = (
-    <AppHeader>
-      <DashboardPicker currentShareTitle={shareTitle ?? "Shared"} />
-      <div className={cn(chipCn, statusAlert ? "border-amber-500/30 bg-amber-500/10 text-amber-100" : "border-emerald-500/30 bg-emerald-500/10 text-emerald-100")}>
-        <Eye className="h-3.5 w-3.5" />{statusLabel}
-      </div>
-    </AppHeader>
-  );
-
-  if (!mounted || loading) {
-    return (
-      <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
-        {header}
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
+      <AppHeader>
+        <DashboardPicker currentShareTitle={snapshot?.dashboard?.title ?? "Shared"} />
+        <div className={cn(chipCn, ok ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-100" : "border-amber-500/30 bg-amber-500/10 text-amber-100")}>
+          <Eye className="h-3.5 w-3.5" />{statusLabel}
+        </div>
+      </AppHeader>
+      {ready ? (
+        <SharedDashboardView snapshot={snapshot} liveError={liveError} />
+      ) : (!mounted || loading) ? (
         <div className="flex flex-1 items-center justify-center gap-2 text-sm text-zinc-500"><LoaderCircle className="h-4 w-4 animate-spin" />Loading…</div>
-      </div>
-    );
-  }
-
-  if (error || !snapshot?.dashboard) {
-    return (
-      <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
-        {header}
+      ) : (
         <div className="flex flex-1 items-center justify-center px-6">
           <div className="max-w-md border border-zinc-800 bg-zinc-900/60 p-6 text-center">
             <AlertTriangle className="mx-auto h-5 w-5 text-amber-300" />
             <h1 className="mt-3 text-sm uppercase tracking-[0.18em] text-zinc-100">Shared session unavailable</h1>
             {error && <div className="mt-4 break-words text-xs text-zinc-500">{error}</div>}
-            <div className="mt-4 break-all text-[11px] uppercase tracking-[0.16em] text-zinc-600">{shareId}</div>
           </div>
         </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
-      {header}
-      <SharedDashboardView snapshot={snapshot} liveError={liveError} />
+      )}
     </div>
   );
 }

--- a/src/components/live-shared-dashboard-view.tsx
+++ b/src/components/live-shared-dashboard-view.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle, Eye, LoaderCircle } from "lucide-react";
 import { AppHeader } from "@/components/app-header";
-import { SharedDashboardView } from "@/components/shared-dashboard-view";
+import { SharedDashboardView, SharedChatSidebar } from "@/components/shared-dashboard-view";
 import { buttonVariants } from "@/components/ui/button";
 import {
   applySharedSessionEvent,
@@ -17,13 +17,10 @@ import { cn } from "@/lib/utils";
 
 export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
   const saveShare = useWidgetStore((s) => s.saveShare);
-  const [mounted, setMounted] = useState(false);
   const [snapshot, setSnapshot] = useState<SharedSessionSnapshotV1 | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [liveError, setLiveError] = useState<string | null>(null);
-
-  useEffect(() => { setMounted(true); }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -69,32 +66,36 @@ export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
     return () => { cancelled = true; if (reconnectTimer !== null) window.clearTimeout(reconnectTimer); es?.close(); };
   }, [shareId, saveShare]);
 
+  const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
   const chipCn = buttonVariants({ size: "sm", className: "gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 uppercase tracking-wider !text-xs pointer-events-none" });
-  const ok = mounted && !loading && !liveError && !error;
-  const statusLabel = !mounted || loading ? "Connecting" : liveError ? "Reconnecting" : error ? "Offline" : "Live sync";
-  const ready = mounted && !loading && snapshot?.dashboard;
+  const ok = !loading && !liveError && !error;
+  const statusLabel = loading ? "Connecting" : liveError ? "Reconnecting" : error ? "Offline" : "Live sync";
+  const ready = !loading && snapshot?.dashboard;
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
-      <AppHeader>
-        <DashboardPicker currentShareTitle={snapshot?.dashboard?.title ?? "Shared"} />
-        <div className={cn(chipCn, ok ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-100" : "border-amber-500/30 bg-amber-500/10 text-amber-100")}>
-          <Eye className="h-3.5 w-3.5" />{statusLabel}
-        </div>
-      </AppHeader>
-      {ready ? (
-        <SharedDashboardView snapshot={snapshot} liveError={liveError} />
-      ) : (!mounted || loading) ? (
-        <div className="flex flex-1 items-center justify-center gap-2 text-sm text-zinc-500"><LoaderCircle className="h-4 w-4 animate-spin" />Loading…</div>
-      ) : (
-        <div className="flex flex-1 items-center justify-center px-6">
-          <div className="max-w-md border border-zinc-800 bg-zinc-900/60 p-6 text-center">
-            <AlertTriangle className="mx-auto h-5 w-5 text-amber-300" />
-            <h1 className="mt-3 text-sm uppercase tracking-[0.18em] text-zinc-100">Shared session unavailable</h1>
-            {error && <div className="mt-4 break-words text-xs text-zinc-500">{error}</div>}
+    <div className="flex h-screen overflow-hidden bg-zinc-900">
+      <div className="flex flex-col flex-1 min-w-0">
+        <AppHeader>
+          <DashboardPicker currentShareTitle={snapshot?.dashboard?.title ?? "Shared"} />
+          <div className={cn(chipCn, ok ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-100" : "border-amber-500/30 bg-amber-500/10 text-amber-100")}>
+            <Eye className="h-3.5 w-3.5" />{statusLabel}
           </div>
-        </div>
-      )}
+        </AppHeader>
+        {ready ? (
+          <SharedDashboardView snapshot={snapshot} selectedWidgetId={selectedWidgetId} onSelectWidgetId={setSelectedWidgetId} />
+        ) : (loading) ? (
+          <div className="flex flex-1 items-center justify-center gap-2 text-sm text-zinc-500"><LoaderCircle className="h-4 w-4 animate-spin" />Loading…</div>
+        ) : (
+          <div className="flex flex-1 items-center justify-center px-6">
+            <div className="max-w-md border border-zinc-800 bg-zinc-900/60 p-6 text-center">
+              <AlertTriangle className="mx-auto h-5 w-5 text-amber-300" />
+              <h1 className="mt-3 text-sm uppercase tracking-[0.18em] text-zinc-100">Shared session unavailable</h1>
+              {error && <div className="mt-4 break-words text-xs text-zinc-500">{error}</div>}
+            </div>
+          </div>
+        )}
+      </div>
+      {ready && <SharedChatSidebar chats={snapshot.chats ?? []} selectedWidgetId={selectedWidgetId} onClose={() => setSelectedWidgetId(null)} />}
     </div>
   );
 }

--- a/src/components/live-shared-dashboard-view.tsx
+++ b/src/components/live-shared-dashboard-view.tsx
@@ -24,8 +24,11 @@ interface BootstrapPayload {
 export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
   const saveShare = useWidgetStore((s) => s.saveShare);
 
+  const [mounted, setMounted] = useState(false);
   const [snapshot, setSnapshot] = useState<SharedSessionSnapshotV1 | null>(null);
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => { setMounted(true); }, []);
   const [error, setError] = useState<string | null>(null);
   const [liveError, setLiveError] = useState<string | null>(null);
 
@@ -123,10 +126,23 @@ export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
     className: "gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 uppercase tracking-wider !text-xs pointer-events-none",
   });
 
-  if (loading) {
+  const shareTitle = snapshot?.dashboard?.title;
+  const statusLabel = !mounted || loading ? "Connecting" : liveError ? "Reconnecting" : error ? "Offline" : "Live sync";
+  const statusAlert = !mounted || loading || liveError || error;
+
+  const header = (
+    <AppHeader>
+      <DashboardPicker currentShareTitle={shareTitle ?? "Shared"} />
+      <div className={cn(chipCn, statusAlert ? "border-amber-500/30 bg-amber-500/10 text-amber-100" : "border-emerald-500/30 bg-emerald-500/10 text-emerald-100")}>
+        <Eye className="h-3.5 w-3.5" />{statusLabel}
+      </div>
+    </AppHeader>
+  );
+
+  if (!mounted || loading) {
     return (
       <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
-        <AppHeader><DashboardPicker currentShareTitle={snapshot?.dashboard?.title} /></AppHeader>
+        {header}
         <div className="flex flex-1 items-center justify-center gap-2 text-sm text-zinc-500"><LoaderCircle className="h-4 w-4 animate-spin" />Loading…</div>
       </div>
     );
@@ -135,7 +151,7 @@ export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
   if (error || !snapshot?.dashboard) {
     return (
       <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
-        <AppHeader><DashboardPicker currentShareTitle={snapshot?.dashboard?.title} /></AppHeader>
+        {header}
         <div className="flex flex-1 items-center justify-center px-6">
           <div className="max-w-md border border-zinc-800 bg-zinc-900/60 p-6 text-center">
             <AlertTriangle className="mx-auto h-5 w-5 text-amber-300" />
@@ -150,12 +166,7 @@ export function LiveSharedDashboardView({ shareId }: { shareId: string }) {
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-zinc-900">
-      <AppHeader>
-        <DashboardPicker currentShareTitle={snapshot?.dashboard?.title} />
-        <div className={cn(chipCn, liveError && "border-amber-500/30 bg-amber-500/10 text-amber-100")}>
-          <Eye className="h-3.5 w-3.5" />{liveError ? "Reconnecting" : "Live sync"}
-        </div>
-      </AppHeader>
+      {header}
       <SharedDashboardView snapshot={snapshot} liveError={liveError} />
     </div>
   );

--- a/src/components/share-dashboard-button.tsx
+++ b/src/components/share-dashboard-button.tsx
@@ -19,8 +19,8 @@ export function ShareDashboardButton() {
     try {
       await flushSyncToServer({ dirtyDashboardIds: [activeDashboardId] });
       const res = await fetch(`/api/dashboards/${activeDashboardId}/share`, { method: "POST" });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error ?? "Share failed");
+      const data = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(data?.error ?? `Share failed (${res.status})`);
       await navigator.clipboard.writeText(data.shareUrl).catch(() => {});
       window.open(data.shareUrl, "_blank");
     } catch (err) {

--- a/src/components/share-dashboard-button.tsx
+++ b/src/components/share-dashboard-button.tsx
@@ -2,107 +2,39 @@
 
 import { useState } from "react";
 import { usePathname } from "next/navigation";
-import { Check, Copy, ExternalLink, Loader2, Share2 } from "lucide-react";
+import { Loader2, Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useWidgetStore } from "@/store/widget-store";
 import { flushSyncToServer } from "@/lib/sync-db";
 
-interface ShareInfo {
-  shareId: string;
-  shareUrl: string;
-  updatedAt: string;
-}
-
 export function ShareDashboardButton() {
   const activeDashboardId = useWidgetStore((s) => s.activeDashboardId);
-  const [shareInfo, setShareInfo] = useState<ShareInfo | null>(null);
   const [loading, setLoading] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [open, setOpen] = useState(false);
-
   const pathname = usePathname();
+
   if (!activeDashboardId || pathname.startsWith("/share/")) return null;
 
   const handleShare = async () => {
     setLoading(true);
-    setError(null);
     try {
       await flushSyncToServer({ dirtyDashboardIds: [activeDashboardId] });
       const res = await fetch(`/api/dashboards/${activeDashboardId}/share`, { method: "POST" });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Share failed");
-      setShareInfo(data as ShareInfo);
+      await navigator.clipboard.writeText(data.shareUrl).catch(() => {});
+      window.open(data.shareUrl, "_blank");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      console.error("Share failed:", err);
     } finally {
       setLoading(false);
     }
   };
 
-  const handleCopy = async () => {
-    if (!shareInfo) return;
-    await navigator.clipboard.writeText(shareInfo.shareUrl);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
   return (
-    <div className="relative">
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={() => { setOpen((v) => !v); if (!open && !shareInfo) handleShare(); }}
-        className="gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 hover:bg-zinc-700"
-      >
-        <Share2 className="h-3.5 w-3.5" />
-        Share
-      </Button>
-
-      {open && (
-        <div className="absolute right-0 top-full z-50 mt-2 w-80 border border-zinc-700 bg-zinc-900 p-4 shadow-xl">
-          <div className="text-[11px] uppercase tracking-[0.2em] text-zinc-500">Share Dashboard</div>
-
-          {loading && (
-            <div className="mt-3 flex items-center gap-2 text-xs text-zinc-400">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />Generating share link…
-            </div>
-          )}
-
-          {error && (
-            <div className="mt-3 text-xs text-red-400">{error}</div>
-          )}
-
-          {shareInfo && !loading && (
-            <div className="mt-3 space-y-3">
-              <div className="flex items-center gap-2">
-                <input
-                  readOnly
-                  value={shareInfo.shareUrl}
-                  className="flex-1 border border-zinc-700 bg-zinc-800 px-2 py-1.5 text-xs text-zinc-200 outline-none"
-                />
-              </div>
-              <div className="flex items-center gap-2">
-                <Button size="sm" variant="ghost" onClick={handleCopy} className="flex-1 gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 hover:bg-zinc-700">
-                  {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                  {copied ? "Copied" : "Copy Link"}
-                </Button>
-                <a
-                  href={shareInfo.shareUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex flex-1 items-center justify-center gap-1.5 border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-700"
-                >
-                  <ExternalLink className="h-3.5 w-3.5" />Open
-                </a>
-              </div>
-              <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
-                Synced {shareInfo.updatedAt.replace("T", " ").replace(".000Z", "Z")}
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+    <Button size="sm" variant="ghost" onClick={handleShare} disabled={loading}
+      className="gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 hover:bg-zinc-700">
+      {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Share2 className="h-3.5 w-3.5" />}
+      Share
+    </Button>
   );
 }

--- a/src/components/share-dashboard-button.tsx
+++ b/src/components/share-dashboard-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { usePathname } from "next/navigation";
 import { Check, Copy, ExternalLink, Loader2, Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useWidgetStore } from "@/store/widget-store";
@@ -20,7 +21,8 @@ export function ShareDashboardButton() {
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
 
-  if (!activeDashboardId) return null;
+  const pathname = usePathname();
+  if (!activeDashboardId || pathname.startsWith("/share/")) return null;
 
   const handleShare = async () => {
     setLoading(true);

--- a/src/components/share-dashboard-button.tsx
+++ b/src/components/share-dashboard-button.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy, ExternalLink, Loader2, Share2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useWidgetStore } from "@/store/widget-store";
+import { flushSyncToServer } from "@/lib/sync-db";
+
+interface ShareInfo {
+  shareId: string;
+  shareUrl: string;
+  updatedAt: string;
+}
+
+export function ShareDashboardButton() {
+  const activeDashboardId = useWidgetStore((s) => s.activeDashboardId);
+  const [shareInfo, setShareInfo] = useState<ShareInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  if (!activeDashboardId) return null;
+
+  const handleShare = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await flushSyncToServer({ dirtyDashboardIds: [activeDashboardId] });
+      const res = await fetch(`/api/dashboards/${activeDashboardId}/share`, { method: "POST" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Share failed");
+      setShareInfo(data as ShareInfo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!shareInfo) return;
+    await navigator.clipboard.writeText(shareInfo.shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative">
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => { setOpen((v) => !v); if (!open && !shareInfo) handleShare(); }}
+        className="gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 hover:bg-zinc-700"
+      >
+        <Share2 className="h-3.5 w-3.5" />
+        Share
+      </Button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-2 w-80 border border-zinc-700 bg-zinc-900 p-4 shadow-xl">
+          <div className="text-[11px] uppercase tracking-[0.2em] text-zinc-500">Share Dashboard</div>
+
+          {loading && (
+            <div className="mt-3 flex items-center gap-2 text-xs text-zinc-400">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />Generating share link…
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-3 text-xs text-red-400">{error}</div>
+          )}
+
+          {shareInfo && !loading && (
+            <div className="mt-3 space-y-3">
+              <div className="flex items-center gap-2">
+                <input
+                  readOnly
+                  value={shareInfo.shareUrl}
+                  className="flex-1 border border-zinc-700 bg-zinc-800 px-2 py-1.5 text-xs text-zinc-200 outline-none"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <Button size="sm" variant="ghost" onClick={handleCopy} className="flex-1 gap-1.5 border border-zinc-700 bg-zinc-800 text-zinc-200 hover:bg-zinc-700">
+                  {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                  {copied ? "Copied" : "Copy Link"}
+                </Button>
+                <a
+                  href={shareInfo.shareUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex flex-1 items-center justify-center gap-1.5 border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-700"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />Open
+                </a>
+              </div>
+              <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+                Synced {shareInfo.updatedAt.replace("T", " ").replace(".000Z", "Z")}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared-dashboard-view.tsx
+++ b/src/components/shared-dashboard-view.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { X } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
-import { ConversationMessages } from "@/components/chat-sidebar";
 import {
   Conversation,
   ConversationContent,
 } from "@/components/ai-elements/conversation";
+import { Message, MessageContent, MessageResponse } from "@/components/ai-elements/message";
 import { CELL_H, CELL_W, InfiniteCanvas, MARGIN } from "@/components/infinite-canvas";
 import { ZoomControls } from "@/components/zoom-controls";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -75,21 +75,16 @@ function PublishedTextBlock({ textBlock }: { textBlock: PublishedTextBlockSnapsh
   );
 }
 
-function SharedChatSidebar({ chats, selectedWidgetId, onClose }: { chats: SharedWidgetChat[]; selectedWidgetId: string | null; onClose: () => void }) {
+export function SharedChatSidebar({ chats, selectedWidgetId, onClose }: { chats: SharedWidgetChat[]; selectedWidgetId: string | null; onClose: () => void }) {
   const activeChat = useMemo(() => {
     if (!selectedWidgetId) return null;
     return chats.find((c) => c.publishedWidgetId === selectedWidgetId) ?? null;
   }, [chats, selectedWidgetId]);
 
-  const widgetMessages = useMemo(() =>
-    (activeChat?.messages ?? []).map((m) => ({ id: m.id, role: m.role, content: m.content, reasoning: m.reasoning })),
-    [activeChat],
-  );
-
   if (!activeChat) return null;
 
   return (
-    <aside className="flex w-full shrink-0 flex-col border-t border-zinc-800 bg-zinc-950/60 lg:h-auto lg:w-[340px] lg:border-t-0 lg:border-l">
+    <aside className="relative flex h-full w-md flex-col border-l border-zinc-800 bg-black">
       <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-2">
         <div className="text-[11px] uppercase tracking-[0.2em] text-zinc-500">
           {activeChat.widgetTitle}
@@ -101,13 +96,23 @@ function SharedChatSidebar({ chats, selectedWidgetId, onClose }: { chats: Shared
       <ScrollArea className="min-h-0 flex-1">
         <Conversation>
           <ConversationContent>
-            <ConversationMessages
-              messages={widgetMessages}
-              isStreaming={false}
-              isReasoningStreaming={false}
-              streamingMsgId={null}
-              activeAction={null}
-            />
+            {activeChat.messages.map((msg) => (
+              <Fragment key={msg.id}>
+                {msg.role === "assistant" && msg.reasoning && (
+                  <details className="w-full mb-1 text-xs text-zinc-500">
+                    <summary className="cursor-pointer hover:text-zinc-300 select-none">
+                      Thought for {msg.reasoningDurationMs != null ? `${Math.round(msg.reasoningDurationMs / 1000)}s` : "a few seconds"}
+                    </summary>
+                    <div className="mt-1 whitespace-pre-wrap text-zinc-600 pl-2 border-l border-zinc-800">{msg.reasoning}</div>
+                  </details>
+                )}
+                {(msg.role === "user" || msg.content) && (
+                  <Message from={msg.role}>
+                    <MessageContent><MessageResponse>{msg.content}</MessageResponse></MessageContent>
+                  </Message>
+                )}
+              </Fragment>
+            ))}
           </ConversationContent>
         </Conversation>
       </ScrollArea>
@@ -115,8 +120,7 @@ function SharedChatSidebar({ chats, selectedWidgetId, onClose }: { chats: Shared
   );
 }
 
-export function SharedDashboardView({ snapshot, liveError }: { snapshot: SharedSessionSnapshotV1; liveError?: string | null }) {
-  const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
+export function SharedDashboardView({ snapshot, selectedWidgetId, onSelectWidgetId }: { snapshot: SharedSessionSnapshotV1; selectedWidgetId: string | null; onSelectWidgetId: (id: string) => void }) {
   const [manualViewport, setManualViewport] = useState<{ panX: number; panY: number; zoom: number } | null>(null);
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
@@ -139,21 +143,20 @@ export function SharedDashboardView({ snapshot, liveError }: { snapshot: SharedS
   if (!dashboard) return null;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-      <div ref={containerRef} className="relative min-h-0 flex-1 overflow-hidden">
+    <div className="flex-1 min-h-0 min-w-0">
+      <div ref={containerRef} className="relative h-full overflow-hidden">
         {canvasItems.length === 0 ? (
           <div className="flex h-full items-center justify-center px-6 text-center text-sm text-zinc-500">No live items yet.</div>
         ) : (
           <>
             <InfiniteCanvas panX={viewport.panX} panY={viewport.panY} zoom={viewport.zoom} onViewportChange={(px, py, z) => setManualViewport({ panX: px, panY: py, zoom: z })}>
-              {dashboard.widgets.map((w) => <PublishedWidgetCard key={`${w.publishedWidgetId}:${w.revision}`} widget={w} active={selectedWidgetId === w.publishedWidgetId} onSelect={setSelectedWidgetId} />)}
+              {dashboard.widgets.map((w) => <PublishedWidgetCard key={`${w.publishedWidgetId}:${w.revision}`} widget={w} active={selectedWidgetId === w.publishedWidgetId} onSelect={onSelectWidgetId} />)}
               {dashboard.textBlocks.map((tb) => <PublishedTextBlock key={tb.id} textBlock={tb} />)}
             </InfiniteCanvas>
             <ZoomControls zoom={viewport.zoom} panX={viewport.panX} panY={viewport.panY} containerWidth={containerSize.width} containerHeight={containerSize.height} widgets={dashboard.widgets} textBlocks={dashboard.textBlocks} onViewportChange={(px, py, z) => setManualViewport({ panX: px, panY: py, zoom: z })} />
           </>
         )}
       </div>
-      <SharedChatSidebar chats={snapshot.chats ?? []} selectedWidgetId={selectedWidgetId} onClose={() => setSelectedWidgetId(null)} />
     </div>
   );
 }

--- a/src/components/shared-dashboard-view.tsx
+++ b/src/components/shared-dashboard-view.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { X } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { ConversationMessages } from "@/components/chat-sidebar";
+import {
+  Conversation,
+  ConversationContent,
+} from "@/components/ai-elements/conversation";
+import { CELL_H, CELL_W, InfiniteCanvas, MARGIN } from "@/components/infinite-canvas";
+import { ZoomControls } from "@/components/zoom-controls";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { DEFAULT_CANVAS_VIEWPORT } from "@/lib/canvas-viewport";
+import type {
+  PublishedCanvasLayout,
+  PublishedTextBlockSnapshotV1,
+  PublishedWidgetSnapshotV1,
+  SharedSessionSnapshotV1,
+  SharedWidgetChat,
+} from "@/lib/share-types";
+
+function gridToPixelX(col: number) { return col * (CELL_W + MARGIN); }
+function gridToPixelY(row: number) { return row * (CELL_H + MARGIN); }
+function gridWidth(cols: number) { return cols * (CELL_W + MARGIN) - MARGIN; }
+function gridHeight(rows: number) { return rows * (CELL_H + MARGIN) - MARGIN; }
+
+function fitViewport(items: Array<{ layout: PublishedCanvasLayout }>, width: number, height: number) {
+  if (items.length === 0 || width === 0 || height === 0) return DEFAULT_CANVAS_VIEWPORT;
+  const stepX = CELL_W + MARGIN, stepY = CELL_H + MARGIN;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const item of items) {
+    const l = item.layout.x * stepX, t = item.layout.y * stepY;
+    minX = Math.min(minX, l); minY = Math.min(minY, t);
+    maxX = Math.max(maxX, l + item.layout.w * stepX - MARGIN);
+    maxY = Math.max(maxY, t + item.layout.h * stepY - MARGIN);
+  }
+  const cw = maxX - minX || stepX, ch = maxY - minY || stepY, pad = 72;
+  const zoom = Math.min(1, Math.min((width - pad * 2) / cw, (height - pad * 2) / ch));
+  return { panX: (width - cw * zoom) / 2 - minX * zoom, panY: (height - ch * zoom) / 2 - minY * zoom, zoom };
+}
+
+function PublishedWidgetCard({ widget, active, onSelect }: { widget: PublishedWidgetSnapshotV1; active: boolean; onSelect: (id: string) => void }) {
+  const pw = gridWidth(widget.layout.w), ph = gridHeight(widget.layout.h);
+  const hasApp = Boolean(widget.files["src/App.tsx"]);
+  return (
+    <div data-widget className="absolute" style={{ left: gridToPixelX(widget.layout.x), top: gridToPixelY(widget.layout.y), width: pw, height: ph }}>
+      <Card className={`h-full gap-0 py-0 ${active ? "border-teal-500/40 bg-zinc-800 ring-teal-500/60" : "border-zinc-700 bg-zinc-800 ring-zinc-700"}`}>
+        <button type="button" onClick={() => onSelect(widget.publishedWidgetId)} className="w-full border-b border-zinc-700 px-3 py-2 text-left transition-colors hover:bg-zinc-800/80">
+          <div className="truncate text-xs font-medium uppercase tracking-wider text-zinc-200">{widget.title}</div>
+        </button>
+        {hasApp ? (
+          <CardContent className="relative flex-1 p-0!">
+            <iframe src={`/api/widget/${widget.publishedWidgetId}/?rev=${encodeURIComponent(widget.revision)}`} title={widget.title} className="absolute inset-0 h-full w-full border-0" />
+          </CardContent>
+        ) : (
+          <CardContent className="flex-1 overflow-auto p-3">
+            <p className="text-xs leading-relaxed text-zinc-400">{widget.description || "No shared app bundle yet."}</p>
+          </CardContent>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+function PublishedTextBlock({ textBlock }: { textBlock: PublishedTextBlockSnapshotV1 }) {
+  return (
+    <div data-widget className="absolute whitespace-pre-wrap break-words text-zinc-100" style={{
+      left: gridToPixelX(textBlock.layout.x), top: gridToPixelY(textBlock.layout.y),
+      width: gridWidth(textBlock.layout.w), minHeight: gridHeight(textBlock.layout.h),
+      fontSize: `${textBlock.fontSize}px`, lineHeight: 1.2, fontWeight: textBlock.fontSize >= 32 ? 600 : 400,
+    }}>
+      {textBlock.text}
+    </div>
+  );
+}
+
+function SharedChatSidebar({ chats, selectedWidgetId, onClose }: { chats: SharedWidgetChat[]; selectedWidgetId: string | null; onClose: () => void }) {
+  const activeChat = useMemo(() => {
+    if (!selectedWidgetId) return null;
+    return chats.find((c) => c.publishedWidgetId === selectedWidgetId) ?? null;
+  }, [chats, selectedWidgetId]);
+
+  const widgetMessages = useMemo(() =>
+    (activeChat?.messages ?? []).map((m) => ({ id: m.id, role: m.role, content: m.content, reasoning: m.reasoning })),
+    [activeChat],
+  );
+
+  if (!activeChat) return null;
+
+  return (
+    <aside className="flex w-full shrink-0 flex-col border-t border-zinc-800 bg-zinc-950/60 lg:h-auto lg:w-[340px] lg:border-t-0 lg:border-l">
+      <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-2">
+        <div className="text-[11px] uppercase tracking-[0.2em] text-zinc-500">
+          {activeChat.widgetTitle}
+        </div>
+        <button type="button" onClick={onClose} className="text-zinc-500 hover:text-zinc-200 transition-colors">
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <Conversation>
+          <ConversationContent>
+            <ConversationMessages
+              messages={widgetMessages}
+              isStreaming={false}
+              isReasoningStreaming={false}
+              streamingMsgId={null}
+              activeAction={null}
+            />
+          </ConversationContent>
+        </Conversation>
+      </ScrollArea>
+    </aside>
+  );
+}
+
+export function SharedDashboardView({ snapshot, liveError }: { snapshot: SharedSessionSnapshotV1; liveError?: string | null }) {
+  const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
+  const [manualViewport, setManualViewport] = useState<{ panX: number; panY: number; zoom: number } | null>(null);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const dashboard = snapshot.dashboard;
+  const canvasItems = useMemo(() => [...(dashboard?.widgets ?? []), ...(dashboard?.textBlocks ?? [])], [dashboard]);
+  const viewport = manualViewport ?? dashboard?.viewport ?? fitViewport(canvasItems, containerSize.width, containerSize.height);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver((entries) => {
+      const e = entries[0];
+      if (e) setContainerSize({ width: e.contentRect.width, height: e.contentRect.height });
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  if (!dashboard) return null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+      <div ref={containerRef} className="relative min-h-0 flex-1 overflow-hidden">
+        {canvasItems.length === 0 ? (
+          <div className="flex h-full items-center justify-center px-6 text-center text-sm text-zinc-500">No live items yet.</div>
+        ) : (
+          <>
+            <InfiniteCanvas panX={viewport.panX} panY={viewport.panY} zoom={viewport.zoom} onViewportChange={(px, py, z) => setManualViewport({ panX: px, panY: py, zoom: z })}>
+              {dashboard.widgets.map((w) => <PublishedWidgetCard key={`${w.publishedWidgetId}:${w.revision}`} widget={w} active={selectedWidgetId === w.publishedWidgetId} onSelect={setSelectedWidgetId} />)}
+              {dashboard.textBlocks.map((tb) => <PublishedTextBlock key={tb.id} textBlock={tb} />)}
+            </InfiniteCanvas>
+            <ZoomControls zoom={viewport.zoom} panX={viewport.panX} panY={viewport.panY} containerWidth={containerSize.width} containerHeight={containerSize.height} widgets={dashboard.widgets} textBlocks={dashboard.textBlocks} onViewportChange={(px, py, z) => setManualViewport({ panX: px, panY: py, zoom: z })} />
+          </>
+        )}
+      </div>
+      <SharedChatSidebar chats={snapshot.chats ?? []} selectedWidgetId={selectedWidgetId} onClose={() => setSelectedWidgetId(null)} />
+    </div>
+  );
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -59,6 +59,9 @@ sqlite.exec(`CREATE TABLE IF NOT EXISTS text_blocks (
   if (!dashColNames.has("text_block_ids_json")) {
     sqlite.exec("ALTER TABLE dashboards ADD COLUMN text_block_ids_json TEXT");
   }
+  if (!dashColNames.has("viewport_json")) {
+    sqlite.exec("ALTER TABLE dashboards ADD COLUMN viewport_json TEXT");
+  }
 }
 
 export const db = drizzle(sqlite, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,6 +6,7 @@ export const dashboards = sqliteTable("dashboards", {
   title: text("title").notNull().default("Dashboard"),
   widgetIdsJson: text("widget_ids_json"),
   textBlockIdsJson: text("text_block_ids_json"),
+  viewportJson: text("viewport_json"),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/db/widgets.ts
+++ b/src/db/widgets.ts
@@ -131,6 +131,7 @@ export function upsertDashboard(data: {
         title: data.title ?? "Dashboard",
         widgetIdsJson: data.widgetIdsJson ?? null,
         textBlockIdsJson: data.textBlockIdsJson ?? null,
+        viewportJson: data.viewportJson ?? null,
       })
       .run();
   }

--- a/src/db/widgets.ts
+++ b/src/db/widgets.ts
@@ -1,5 +1,6 @@
 import { eq, sql } from "drizzle-orm";
 import { db, schema } from ".";
+import { isPublishedWidgetId } from "@/lib/share";
 
 const { widgets, dashboards, textBlocks } = schema;
 
@@ -115,6 +116,7 @@ export function upsertDashboard(data: {
   title?: string;
   widgetIdsJson?: string | null;
   textBlockIdsJson?: string | null;
+  viewportJson?: string | null;
 }) {
   const existing = getDashboard(data.id);
   if (existing) {
@@ -136,6 +138,14 @@ export function upsertDashboard(data: {
 
 export function deleteDashboard(id: string) {
   db.delete(dashboards).where(eq(dashboards.id, id)).run();
+}
+
+export function getDashboardByWidgetId(widgetId: string): DashboardRecord | undefined {
+  return db
+    .select()
+    .from(dashboards)
+    .where(sql`EXISTS (SELECT 1 FROM json_each(${dashboards.widgetIdsJson}) WHERE json_each.value = ${widgetId})`)
+    .get();
 }
 
 // ── Text Blocks ──
@@ -179,7 +189,7 @@ export function deleteTextBlock(id: string) {
 // ── Bulk sync (for local-first push/pull) ──
 
 export function syncState(data: {
-  dashboards: Array<{ id: string; title: string; widgetIds: string[]; textBlockIds?: string[]; createdAt: number }>;
+  dashboards: Array<{ id: string; title: string; widgetIds: string[]; textBlockIds?: string[]; createdAt: number; viewport?: unknown }>;
   widgets: Array<{
     id: string;
     title: string;
@@ -196,12 +206,29 @@ export function syncState(data: {
     layout: unknown;
   }>;
 }) {
+  const nextWidgetIds = new Set(data.widgets.map((w) => w.id));
+  const nextTextBlockIds = new Set((data.textBlocks ?? []).map((tb) => tb.id));
+  const nextDashboardIds = new Set(data.dashboards.map((d) => d.id));
+
+  for (const existing of getAllWidgets()) {
+    if (!nextWidgetIds.has(existing.id) && !isPublishedWidgetId(existing.id)) {
+      deleteWidget(existing.id);
+    }
+  }
+  for (const existing of getAllTextBlocks()) {
+    if (!nextTextBlockIds.has(existing.id)) deleteTextBlock(existing.id);
+  }
+  for (const existing of getAllDashboards()) {
+    if (!nextDashboardIds.has(existing.id)) deleteDashboard(existing.id);
+  }
+
   for (const d of data.dashboards) {
     upsertDashboard({
       id: d.id,
       title: d.title,
       widgetIdsJson: JSON.stringify(d.widgetIds),
       textBlockIdsJson: JSON.stringify(d.textBlockIds ?? []),
+      ...(d.viewport != null ? { viewportJson: JSON.stringify(d.viewport) } : {}),
     });
   }
   for (const w of data.widgets) {

--- a/src/lib/__tests__/share-types.test.ts
+++ b/src/lib/__tests__/share-types.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySharedSessionEvent,
+  buildEmptySharedSessionSnapshot,
+  buildSharedSessionReplayFrames,
+  buildSharedSessionReplaySnapshot,
+  findActiveSharedTraceEvent,
+  findLatestSharedTraceEvent,
+  SharedSessionEventV1Schema,
+  type SharedDashboardStateEventV1,
+  type SharedTraceEventEnvelopeV1,
+  type PublishedTraceEventV1,
+  type DashboardSharedStateV1,
+} from "@/lib/share-types";
+
+const SHARE_ID = "shr_test";
+
+function makeDashboardState(overrides: Partial<DashboardSharedStateV1> = {}): DashboardSharedStateV1 {
+  return { version: "v1", shareId: SHARE_ID, dashboardId: "dash-1", title: "Test", updatedAt: new Date().toISOString(), textBlocks: [], widgets: [], ...overrides };
+}
+
+function makeDashboardEvent(state?: DashboardSharedStateV1): SharedDashboardStateEventV1 {
+  const s = state ?? makeDashboardState();
+  return { version: "v1", kind: "dashboard.state", shareId: SHARE_ID, dashboardId: "dash-1", at: s.updatedAt, stateHash: "hash", state: s };
+}
+
+function makeTraceEvent(kind: PublishedTraceEventV1["kind"] = "tool-call", id = "ev-1"): SharedTraceEventEnvelopeV1 {
+  return {
+    version: "v1", kind: "trace.event", shareId: SHARE_ID, dashboardId: "dash-1", at: new Date().toISOString(),
+    event: { id, runId: "run-1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "Widget", kind, at: new Date().toISOString(), detail: `Detail for ${kind}` },
+  };
+}
+
+describe("SharedSessionEventV1Schema", () => {
+  it("validates a dashboard state event", () => {
+    const result = SharedSessionEventV1Schema.safeParse(makeDashboardEvent());
+    expect(result.success).toBe(true);
+  });
+
+  it("validates a trace event", () => {
+    const result = SharedSessionEventV1Schema.safeParse(makeTraceEvent());
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid events", () => {
+    const result = SharedSessionEventV1Schema.safeParse({ version: "v1", kind: "unknown" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("applySharedSessionEvent", () => {
+  it("applies dashboard state", () => {
+    const snapshot = buildEmptySharedSessionSnapshot(SHARE_ID);
+    const state = makeDashboardState({ title: "Updated" });
+    const next = applySharedSessionEvent(snapshot, makeDashboardEvent(state));
+    expect(next.dashboard?.title).toBe("Updated");
+  });
+
+  it("applies trace events", () => {
+    const snapshot = buildEmptySharedSessionSnapshot(SHARE_ID);
+    const next = applySharedSessionEvent(snapshot, makeTraceEvent("run-start"));
+    expect(next.trace.events).toHaveLength(1);
+    expect(next.trace.events[0].kind).toBe("run-start");
+  });
+});
+
+describe("buildSharedSessionReplayFrames", () => {
+  it("returns empty for no trace events", () => {
+    expect(buildSharedSessionReplayFrames([])).toEqual([]);
+    expect(buildSharedSessionReplayFrames([makeDashboardEvent()])).toEqual([]);
+  });
+
+  it("builds frames from trace events", () => {
+    const events = [makeDashboardEvent(), makeTraceEvent("run-start", "e1"), makeTraceEvent("tool-call", "e2")];
+    const frames = buildSharedSessionReplayFrames(events);
+    expect(frames.length).toBe(3); // null frame + 2 trace frames
+    expect(frames[0].traceEvent).toBeNull();
+    expect(frames[1].traceEvent?.kind).toBe("run-start");
+  });
+});
+
+describe("findActiveSharedTraceEvent", () => {
+  it("returns null for empty events", () => {
+    expect(findActiveSharedTraceEvent([])).toBeNull();
+  });
+
+  it("returns active event when run is not finished", () => {
+    const events: PublishedTraceEventV1[] = [
+      { id: "1", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-start", at: "", detail: "" },
+      { id: "2", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "tool-call", at: "", detail: "" },
+    ];
+    expect(findActiveSharedTraceEvent(events)?.id).toBe("2");
+  });
+
+  it("returns null when run is finished", () => {
+    const events: PublishedTraceEventV1[] = [
+      { id: "1", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-start", at: "", detail: "" },
+      { id: "2", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-finished", at: "", detail: "" },
+    ];
+    expect(findActiveSharedTraceEvent(events)).toBeNull();
+  });
+});
+
+describe("findLatestSharedTraceEvent", () => {
+  it("returns the last event", () => {
+    const events: PublishedTraceEventV1[] = [
+      { id: "1", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-start", at: "", detail: "" },
+      { id: "2", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-finished", at: "", detail: "" },
+    ];
+    expect(findLatestSharedTraceEvent(events)?.id).toBe("2");
+  });
+});

--- a/src/lib/__tests__/share-types.test.ts
+++ b/src/lib/__tests__/share-types.test.ts
@@ -2,14 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   applySharedSessionEvent,
   buildEmptySharedSessionSnapshot,
-  buildSharedSessionReplayFrames,
-  buildSharedSessionReplaySnapshot,
-  findActiveSharedTraceEvent,
-  findLatestSharedTraceEvent,
   SharedSessionEventV1Schema,
   type SharedDashboardStateEventV1,
   type SharedTraceEventEnvelopeV1,
-  type PublishedTraceEventV1,
+  type PublishedTraceEventKind,
   type DashboardSharedStateV1,
 } from "@/lib/share-types";
 
@@ -24,7 +20,7 @@ function makeDashboardEvent(state?: DashboardSharedStateV1): SharedDashboardStat
   return { version: "v1", kind: "dashboard.state", shareId: SHARE_ID, dashboardId: "dash-1", at: s.updatedAt, stateHash: "hash", state: s };
 }
 
-function makeTraceEvent(kind: PublishedTraceEventV1["kind"] = "tool-call", id = "ev-1"): SharedTraceEventEnvelopeV1 {
+function makeTraceEvent(kind: PublishedTraceEventKind = "tool-call", id = "ev-1"): SharedTraceEventEnvelopeV1 {
   return {
     version: "v1", kind: "trace.event", shareId: SHARE_ID, dashboardId: "dash-1", at: new Date().toISOString(),
     event: { id, runId: "run-1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "Widget", kind, at: new Date().toISOString(), detail: `Detail for ${kind}` },
@@ -61,52 +57,5 @@ describe("applySharedSessionEvent", () => {
     const next = applySharedSessionEvent(snapshot, makeTraceEvent("run-start"));
     expect(next.trace.events).toHaveLength(1);
     expect(next.trace.events[0].kind).toBe("run-start");
-  });
-});
-
-describe("buildSharedSessionReplayFrames", () => {
-  it("returns empty for no trace events", () => {
-    expect(buildSharedSessionReplayFrames([])).toEqual([]);
-    expect(buildSharedSessionReplayFrames([makeDashboardEvent()])).toEqual([]);
-  });
-
-  it("builds frames from trace events", () => {
-    const events = [makeDashboardEvent(), makeTraceEvent("run-start", "e1"), makeTraceEvent("tool-call", "e2")];
-    const frames = buildSharedSessionReplayFrames(events);
-    expect(frames.length).toBe(3); // null frame + 2 trace frames
-    expect(frames[0].traceEvent).toBeNull();
-    expect(frames[1].traceEvent?.kind).toBe("run-start");
-  });
-});
-
-describe("findActiveSharedTraceEvent", () => {
-  it("returns null for empty events", () => {
-    expect(findActiveSharedTraceEvent([])).toBeNull();
-  });
-
-  it("returns active event when run is not finished", () => {
-    const events: PublishedTraceEventV1[] = [
-      { id: "1", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-start", at: "", detail: "" },
-      { id: "2", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "tool-call", at: "", detail: "" },
-    ];
-    expect(findActiveSharedTraceEvent(events)?.id).toBe("2");
-  });
-
-  it("returns null when run is finished", () => {
-    const events: PublishedTraceEventV1[] = [
-      { id: "1", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-start", at: "", detail: "" },
-      { id: "2", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-finished", at: "", detail: "" },
-    ];
-    expect(findActiveSharedTraceEvent(events)).toBeNull();
-  });
-});
-
-describe("findLatestSharedTraceEvent", () => {
-  it("returns the last event", () => {
-    const events: PublishedTraceEventV1[] = [
-      { id: "1", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-start", at: "", detail: "" },
-      { id: "2", runId: "r1", shareId: SHARE_ID, publishedWidgetId: "pw-1", widgetTitle: "W", kind: "run-finished", at: "", detail: "" },
-    ];
-    expect(findLatestSharedTraceEvent(events)?.id).toBe("2");
   });
 });

--- a/src/lib/__tests__/share.test.ts
+++ b/src/lib/__tests__/share.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { deriveShareId, getSessionStreamId, getPublishedWidgetId, isPublishedWidgetId } from "@/lib/share";
+
+const TEST_SECRET = "test-secret-for-share-ids";
+
+describe("deriveShareId", () => {
+  it("produces a stable ID for the same dashboard", () => {
+    const a = deriveShareId("dash-1", TEST_SECRET);
+    const b = deriveShareId("dash-1", TEST_SECRET);
+    expect(a).toBe(b);
+  });
+
+  it("produces different IDs for different dashboards", () => {
+    const a = deriveShareId("dash-1", TEST_SECRET);
+    const b = deriveShareId("dash-2", TEST_SECRET);
+    expect(a).not.toBe(b);
+  });
+
+  it("starts with shr_ prefix", () => {
+    expect(deriveShareId("dash-1", TEST_SECRET)).toMatch(/^shr_/);
+  });
+});
+
+describe("getSessionStreamId", () => {
+  it("appends .session suffix", () => {
+    expect(getSessionStreamId("shr_abc")).toBe("shr_abc.session");
+  });
+});
+
+describe("getPublishedWidgetId", () => {
+  it("creates a composite ID", () => {
+    expect(getPublishedWidgetId("shr_abc", "widget-1")).toBe("share--shr_abc--widget-1");
+  });
+});
+
+describe("isPublishedWidgetId", () => {
+  it("returns true for published IDs", () => {
+    expect(isPublishedWidgetId("share--shr_abc--widget-1")).toBe(true);
+  });
+
+  it("returns false for regular IDs", () => {
+    expect(isPublishedWidgetId("widget-1")).toBe(false);
+  });
+});

--- a/src/lib/canvas-viewport.ts
+++ b/src/lib/canvas-viewport.ts
@@ -1,0 +1,35 @@
+export interface CanvasViewportSnapshot {
+  panX: number;
+  panY: number;
+  zoom: number;
+}
+
+export const DEFAULT_CANVAS_VIEWPORT: CanvasViewportSnapshot = {
+  panX: 24,
+  panY: 60,
+  zoom: 1,
+};
+
+export function isCanvasViewportSnapshot(
+  value: unknown,
+): value is CanvasViewportSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.panX === "number" &&
+    typeof v.panY === "number" &&
+    typeof v.zoom === "number"
+  );
+}
+
+export function normalizeCanvasViewport(
+  value: Partial<CanvasViewportSnapshot> | null | undefined,
+  fallback = DEFAULT_CANVAS_VIEWPORT,
+): CanvasViewportSnapshot {
+  if (!value) return fallback;
+  return {
+    panX: typeof value.panX === "number" ? value.panX : fallback.panX,
+    panY: typeof value.panY === "number" ? value.panY : fallback.panY,
+    zoom: typeof value.zoom === "number" ? value.zoom : fallback.zoom,
+  };
+}

--- a/src/lib/durable-stream.ts
+++ b/src/lib/durable-stream.ts
@@ -103,6 +103,11 @@ export function createDurableStreamClient(baseUrl: string) {
   }
 
   return {
+    async ensureBucket(bucket: string) {
+      const response = await request(`/ds/${encodeSegment(bucket)}`, { method: "PUT" });
+      await assertResponseOk(response, [409]);
+    },
+
     async createStream(bucket: string, streamId: string) {
       const response = await request(streamPath(bucket, streamId), {
         method: "PUT",

--- a/src/lib/durable-stream.ts
+++ b/src/lib/durable-stream.ts
@@ -1,0 +1,171 @@
+export interface DurableStreamAppendResult {
+  body: string;
+  nextOffset: string;
+}
+
+export interface DurableStreamHeadResult {
+  exists: boolean;
+  nextOffset: string | null;
+}
+
+export interface DurableStreamBootstrapPart {
+  contentType: string | null;
+  body: string;
+}
+
+export interface DurableStreamBootstrapResult {
+  snapshotOffset: string | null;
+  nextOffset: string | null;
+  upToDate: boolean;
+  parts: DurableStreamBootstrapPart[];
+}
+
+export const DEFAULT_DURABLE_STREAM_BASE_URL = "https://stream.tonbo.dev";
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/+$/, "");
+}
+
+function encodeSegment(value: string) {
+  return encodeURIComponent(value);
+}
+
+async function assertResponseOk(response: Response, allowedStatuses: number[] = []) {
+  if (response.ok || allowedStatuses.includes(response.status)) return;
+  const text = await response.text();
+  throw new Error(text.trim() || `${response.status} ${response.statusText}`);
+}
+
+function getNextOffset(response: Response) {
+  return response.headers.get("Stream-Next-Offset") ?? response.headers.get("stream-next-offset");
+}
+
+function getSnapshotOffset(response: Response) {
+  return response.headers.get("Stream-Snapshot-Offset") ?? response.headers.get("stream-snapshot-offset");
+}
+
+function getUpToDate(response: Response) {
+  const value = response.headers.get("Stream-Up-To-Date") ?? response.headers.get("stream-up-to-date");
+  return value === "true";
+}
+
+function getMultipartBoundary(contentType: string) {
+  const match = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i);
+  if (!match) return null;
+  return (match[1] ?? match[2] ?? "").replace(/^"|"$/g, "").trim() || null;
+}
+
+function parseMultipartHeaders(headerBlock: string) {
+  const headers = new Map<string, string>();
+  for (const line of headerBlock.split("\n")) {
+    const sep = line.indexOf(":");
+    if (sep === -1) continue;
+    const name = line.slice(0, sep).trim().toLowerCase();
+    const value = line.slice(sep + 1).trim();
+    if (name) headers.set(name, value);
+  }
+  return headers;
+}
+
+function parseMultipartMixed(body: string, boundary: string): DurableStreamBootstrapPart[] {
+  const normalized = body.replace(/\r\n/g, "\n");
+  const marker = `--${boundary}`;
+  const segments = normalized.split(marker);
+  const parts: DurableStreamBootstrapPart[] = [];
+
+  for (const segment of segments) {
+    const trimmedStart = segment.replace(/^\n+/, "");
+    const trimmed = trimmedStart.trim();
+    if (!trimmed || trimmed === "--") continue;
+
+    const bodyWithoutClosing = trimmedStart.replace(/\n--\s*$/, "");
+    const sep = bodyWithoutClosing.indexOf("\n\n");
+    if (sep === -1) continue;
+
+    const headers = parseMultipartHeaders(bodyWithoutClosing.slice(0, sep));
+    const partBody = bodyWithoutClosing.slice(sep + 2).replace(/\n$/, "");
+    parts.push({ contentType: headers.get("content-type") ?? null, body: partBody });
+  }
+  return parts;
+}
+
+export function createDurableStreamClient(baseUrl: string) {
+  const normalizedBaseUrl = trimTrailingSlash(baseUrl);
+
+  async function request(path: string, init: RequestInit = {}, options: { timeoutMs?: number | null } = {}) {
+    const { timeoutMs = 10_000 } = options;
+    const signal = init.signal ?? (timeoutMs === null ? undefined : AbortSignal.timeout(timeoutMs));
+    return fetch(`${normalizedBaseUrl}${path}`, { ...init, ...(signal ? { signal } : {}) });
+  }
+
+  function streamPath(bucket: string, streamId: string) {
+    return `/ds/${encodeSegment(bucket)}/${encodeSegment(streamId)}`;
+  }
+
+  return {
+    async createStream(bucket: string, streamId: string) {
+      const response = await request(streamPath(bucket, streamId), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+      });
+      await assertResponseOk(response, [409]);
+    },
+
+    async appendJson<T>(bucket: string, streamId: string, payload: T): Promise<DurableStreamAppendResult> {
+      const body = JSON.stringify(payload);
+      const response = await request(streamPath(bucket, streamId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      await assertResponseOk(response);
+      const nextOffset = getNextOffset(response);
+      if (!nextOffset) throw new Error("Append response missing Stream-Next-Offset");
+      return { body, nextOffset };
+    },
+
+    async publishSnapshot(bucket: string, streamId: string, offset: string, body: string) {
+      const response = await request(
+        `${streamPath(bucket, streamId)}/snapshot/${encodeSegment(offset)}`,
+        { method: "PUT", headers: { "Content-Type": "application/json" }, body },
+      );
+      await assertResponseOk(response);
+    },
+
+    async bootstrap(bucket: string, streamId: string): Promise<DurableStreamBootstrapResult | null> {
+      const response = await request(`${streamPath(bucket, streamId)}/bootstrap`, {
+        method: "GET",
+        headers: { Accept: "multipart/mixed" },
+      });
+      if (response.status === 404) return null;
+      await assertResponseOk(response);
+
+      const contentType = response.headers.get("Content-Type") ?? "";
+      const boundary = getMultipartBoundary(contentType);
+      if (!boundary) throw new Error("Bootstrap response missing multipart boundary");
+
+      const body = await response.text();
+      return {
+        snapshotOffset: getSnapshotOffset(response),
+        nextOffset: getNextOffset(response),
+        upToDate: getUpToDate(response),
+        parts: parseMultipartMixed(body, boundary),
+      };
+    },
+
+    async head(bucket: string, streamId: string): Promise<DurableStreamHeadResult> {
+      const response = await request(streamPath(bucket, streamId), { method: "HEAD" });
+      if (response.status === 404) return { exists: false, nextOffset: null };
+      await assertResponseOk(response);
+      return { exists: true, nextOffset: getNextOffset(response) };
+    },
+  };
+}
+
+export function getDurableStreamBaseUrl() {
+  return process.env.DURABLE_STREAM_BASE_URL?.trim() || DEFAULT_DURABLE_STREAM_BASE_URL;
+}
+
+export function getDurableStreamClient() {
+  return createDurableStreamClient(getDurableStreamBaseUrl());
+}

--- a/src/lib/share-projection.ts
+++ b/src/lib/share-projection.ts
@@ -1,0 +1,118 @@
+import { createHash } from "node:crypto";
+import { getDashboard, getWidget, getTextBlock, getWidgetFiles, upsertWidget } from "@/db/widgets";
+import { buildWidget, rebuildWidget } from "@/lib/widget-runner";
+import { getPublishedWidgetId } from "@/lib/share";
+import {
+  isCanvasViewportSnapshot,
+  normalizeCanvasViewport,
+  DEFAULT_CANVAS_VIEWPORT,
+  type CanvasViewportSnapshot,
+} from "@/lib/canvas-viewport";
+import type { DashboardSharedStateV1, PublishedCanvasLayout } from "@/lib/share-types";
+
+export interface DashboardPublishSource {
+  dashboardId: string;
+  title: string;
+  viewport: CanvasViewportSnapshot;
+  widgets: Array<{ id: string; title: string; description: string; layout: PublishedCanvasLayout; files: Record<string, string> }>;
+  textBlocks: Array<{ id: string; text: string; fontSize: number; layout: PublishedCanvasLayout }>;
+}
+
+function parseStringArray(value: string | null | undefined): string[] {
+  if (!value) return [];
+  try { const p = JSON.parse(value); return Array.isArray(p) ? p.filter((e): e is string => typeof e === "string") : []; }
+  catch { return []; }
+}
+
+function parseLayout(value: string | null | undefined, fallback: PublishedCanvasLayout): PublishedCanvasLayout {
+  if (!value) return fallback;
+  try {
+    const p = JSON.parse(value) as Partial<PublishedCanvasLayout>;
+    return { x: typeof p.x === "number" ? p.x : fallback.x, y: typeof p.y === "number" ? p.y : fallback.y, w: typeof p.w === "number" ? p.w : fallback.w, h: typeof p.h === "number" ? p.h : fallback.h };
+  } catch { return fallback; }
+}
+
+function parseViewport(value: string | null | undefined): CanvasViewportSnapshot {
+  if (!value) return DEFAULT_CANVAS_VIEWPORT;
+  try { const p = JSON.parse(value); return isCanvasViewportSnapshot(p) ? normalizeCanvasViewport(p) : DEFAULT_CANVAS_VIEWPORT; }
+  catch { return DEFAULT_CANVAS_VIEWPORT; }
+}
+
+function sortStringRecord(value: Record<string, string>) {
+  return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function hashString(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function buildWidgetRevision(files: Record<string, string>) {
+  return hashString(JSON.stringify(sortStringRecord(files))).slice(0, 16);
+}
+
+export function loadDashboardPublishSource(dashboardId: string): DashboardPublishSource {
+  const dashboard = getDashboard(dashboardId);
+  if (!dashboard) throw new Error(`Dashboard not found: ${dashboardId}`);
+
+  const widgetIds = parseStringArray(dashboard.widgetIdsJson);
+  const textBlockIds = parseStringArray(dashboard.textBlockIdsJson);
+
+  return {
+    dashboardId: dashboard.id,
+    title: dashboard.title,
+    viewport: parseViewport(dashboard.viewportJson),
+    widgets: widgetIds.flatMap((id) => {
+      const w = getWidget(id);
+      if (!w) return [];
+      return [{ id: w.id, title: w.title, description: w.description, layout: parseLayout(w.layoutJson, { x: 0, y: 0, w: 4, h: 3 }), files: getWidgetFiles(id) }];
+    }),
+    textBlocks: textBlockIds.flatMap((id) => {
+      const tb = getTextBlock(id);
+      if (!tb) return [];
+      return [{ id: tb.id, text: tb.text, fontSize: tb.fontSize, layout: parseLayout(tb.layoutJson, { x: 0, y: 0, w: 3, h: 1 }) }];
+    }),
+  };
+}
+
+export function buildDashboardSharedState(source: DashboardPublishSource, shareId: string, updatedAt = new Date().toISOString()): DashboardSharedStateV1 {
+  return {
+    version: "v1",
+    shareId,
+    dashboardId: source.dashboardId,
+    title: source.title,
+    updatedAt,
+    viewport: source.viewport,
+    textBlocks: source.textBlocks.map((tb) => ({ id: tb.id, text: tb.text, fontSize: tb.fontSize, layout: tb.layout })),
+    widgets: source.widgets.map((w) => {
+      const files = sortStringRecord(w.files);
+      return { sourceWidgetId: w.id, publishedWidgetId: getPublishedWidgetId(shareId, w.id), revision: buildWidgetRevision(files), title: w.title, description: w.description, layout: w.layout, files };
+    }),
+  };
+}
+
+export function buildDashboardStateContentHash(state: DashboardSharedStateV1): string {
+  const { updatedAt: _, ...stable } = state;
+  return hashString(JSON.stringify(stable));
+}
+
+export async function materializePublishedWidgets(state: DashboardSharedStateV1, { waitForBuild }: { waitForBuild: boolean }) {
+  for (const widget of state.widgets) {
+    const existing = getWidget(widget.publishedWidgetId);
+    const nextFilesJson = JSON.stringify(widget.files);
+    const filesChanged = existing?.filesJson !== nextFilesJson;
+
+    upsertWidget({
+      id: widget.publishedWidgetId,
+      title: widget.title,
+      description: widget.description,
+      code: widget.files["src/App.tsx"] ?? null,
+      filesJson: nextFilesJson,
+      layoutJson: JSON.stringify(widget.layout),
+      messagesJson: JSON.stringify([]),
+    });
+
+    if (!filesChanged || !widget.files["src/App.tsx"]) continue;
+    if (waitForBuild) await buildWidget(widget.publishedWidgetId);
+    else rebuildWidget(widget.publishedWidgetId).catch((err) => console.error(`Failed to rebuild ${widget.publishedWidgetId}:`, err));
+  }
+}

--- a/src/lib/share-recorder.ts
+++ b/src/lib/share-recorder.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "node:crypto";
+import { getWidget, getDashboardByWidgetId } from "@/db/widgets";
+import { deriveShareId, getSessionStreamId, getPublishedWidgetId, SHARE_BUCKET } from "@/lib/share";
+import { getDurableStreamClient } from "@/lib/durable-stream";
+import { loadDashboardPublishSource, buildDashboardSharedState, buildDashboardStateContentHash, materializePublishedWidgets } from "@/lib/share-projection";
+import type { PublishedTraceEventKind, SharedChatMessage } from "@/lib/share-types";
+
+export interface SharedSessionRecorder {
+  shareId: string;
+  dashboardId: string;
+  publishedWidgetId: string;
+  widgetTitle: string;
+  startRun: (at?: string) => void;
+  record: (kind: PublishedTraceEventKind, detail: string, extra?: { toolName?: string; path?: string; at?: string }) => void;
+  finish: (at?: string) => void;
+  flushMessages: (messages: SharedChatMessage[]) => void;
+  flush: () => Promise<void>;
+}
+
+async function isShared(shareId: string) {
+  const ds = getDurableStreamClient();
+  const head = await ds.head(SHARE_BUCKET, getSessionStreamId(shareId));
+  return head.exists;
+}
+
+export async function maybeCreateTraceRecorder(widgetId: string): Promise<SharedSessionRecorder | null> {
+  const widget = getWidget(widgetId);
+  if (!widget) return null;
+  const dashboard = getDashboardByWidgetId(widgetId);
+  if (!dashboard) return null;
+
+  const shareId = deriveShareId(dashboard.id);
+  if (!(await isShared(shareId))) return null;
+
+  const publishedWidgetId = getPublishedWidgetId(shareId, widgetId);
+  const runId = randomUUID();
+  const streamId = getSessionStreamId(shareId);
+  let pendingFlush: Promise<void> = Promise.resolve();
+
+  const enqueue = (task: () => Promise<void>) => {
+    pendingFlush = pendingFlush.then(task).catch((err) => console.error("[share-recorder] flush error:", err));
+  };
+
+  const appendTrace = (kind: PublishedTraceEventKind, detail: string, extra: { toolName?: string; path?: string; at?: string } = {}) => {
+    const event = {
+      version: "v1" as const, kind: "trace.event" as const, shareId, dashboardId: dashboard.id, at: extra.at ?? new Date().toISOString(),
+      event: { id: randomUUID(), runId, shareId, publishedWidgetId, widgetTitle: widget.title, kind, at: extra.at ?? new Date().toISOString(), detail, ...(extra.toolName ? { toolName: extra.toolName } : {}), ...(extra.path ? { path: extra.path } : {}) },
+    };
+    enqueue(async () => { await getDurableStreamClient().appendJson(SHARE_BUCKET, streamId, event); });
+  };
+
+  return {
+    shareId, dashboardId: dashboard.id, publishedWidgetId, widgetTitle: widget.title,
+    startRun(at = new Date().toISOString()) {
+      appendTrace("run-start", `Started run for ${widget.title}`, { at });
+    },
+    record(kind, detail, extra) { appendTrace(kind, detail, extra ?? {}); },
+    finish(at = new Date().toISOString()) { void at; },
+    flushMessages(messages: SharedChatMessage[]) {
+      const event = {
+        version: "v1" as const, kind: "chat.messages" as const,
+        shareId, dashboardId: dashboard.id, publishedWidgetId, widgetTitle: widget.title,
+        at: new Date().toISOString(), messages,
+      };
+      enqueue(async () => { await getDurableStreamClient().appendJson(SHARE_BUCKET, streamId, event); });
+    },
+    flush() { return pendingFlush; },
+  };
+}
+
+export async function publishDashboardStateForWidgetIfShared(widgetId: string) {
+  const dashboard = getDashboardByWidgetId(widgetId);
+  if (!dashboard) return;
+  const shareId = deriveShareId(dashboard.id);
+  if (!(await isShared(shareId))) return;
+
+  const source = loadDashboardPublishSource(dashboard.id);
+  const state = buildDashboardSharedState(source, shareId);
+  await materializePublishedWidgets(state, { waitForBuild: false });
+
+  const streamId = getSessionStreamId(shareId);
+  const ds = getDurableStreamClient();
+  const event = { version: "v1" as const, kind: "dashboard.state" as const, shareId, dashboardId: dashboard.id, at: state.updatedAt, stateHash: buildDashboardStateContentHash(state), state };
+  await ds.appendJson(SHARE_BUCKET, streamId, event);
+}

--- a/src/lib/share-types.ts
+++ b/src/lib/share-types.ts
@@ -93,6 +93,7 @@ export interface SharedChatMessage {
   role: "user" | "assistant";
   content: string;
   reasoning?: string;
+  reasoningDurationMs?: number;
 }
 
 export interface SharedChatMessagesEventV1 {
@@ -167,7 +168,7 @@ const SharedTraceEventEnvelopeV1Schema = z.object({
 
 const SharedChatMessageSchema = z.object({
   id: z.string(), role: z.enum(["user", "assistant"]), content: z.string(),
-  reasoning: z.string().optional(),
+  reasoning: z.string().optional(), reasoningDurationMs: z.number().optional(),
 });
 
 const SharedChatMessagesEventV1Schema = z.object({

--- a/src/lib/share-types.ts
+++ b/src/lib/share-types.ts
@@ -1,0 +1,349 @@
+import { z } from "zod";
+import { isCanvasViewportSnapshot, type CanvasViewportSnapshot } from "@/lib/canvas-viewport";
+
+export const MAX_SHARED_TRACE_EVENTS = 500;
+
+// ── Type definitions ──
+
+export interface PublishedCanvasLayout {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface PublishedTextBlockSnapshotV1 {
+  id: string;
+  text: string;
+  fontSize: number;
+  layout: PublishedCanvasLayout;
+}
+
+export interface PublishedWidgetSnapshotV1 {
+  sourceWidgetId: string;
+  publishedWidgetId: string;
+  revision: string;
+  title: string;
+  description: string;
+  layout: PublishedCanvasLayout;
+  files: Record<string, string>;
+}
+
+export interface DashboardSharedStateV1 {
+  version: "v1";
+  shareId: string;
+  dashboardId: string;
+  title: string;
+  updatedAt: string;
+  viewport?: CanvasViewportSnapshot | null;
+  textBlocks: PublishedTextBlockSnapshotV1[];
+  widgets: PublishedWidgetSnapshotV1[];
+}
+
+export type PublishedTraceEventKind =
+  | "run-start"
+  | "tool-call"
+  | "file-written"
+  | "run-finished"
+  | "run-abort"
+  | "run-error";
+
+export interface PublishedTraceEventV1 {
+  id: string;
+  runId: string;
+  shareId: string;
+  publishedWidgetId: string;
+  widgetTitle: string;
+  kind: PublishedTraceEventKind;
+  at: string;
+  detail: string;
+  toolName?: string;
+  path?: string;
+}
+
+export interface SharedTraceStateV1 {
+  version: "v1";
+  shareId: string;
+  updatedAt: string;
+  nextOffset?: string | null;
+  events: PublishedTraceEventV1[];
+}
+
+export interface SharedDashboardStateEventV1 {
+  version: "v1";
+  kind: "dashboard.state";
+  shareId: string;
+  dashboardId: string;
+  at: string;
+  stateHash: string;
+  state: DashboardSharedStateV1;
+}
+
+export interface SharedTraceEventEnvelopeV1 {
+  version: "v1";
+  kind: "trace.event";
+  shareId: string;
+  dashboardId: string;
+  at: string;
+  event: PublishedTraceEventV1;
+}
+
+export interface SharedChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  reasoning?: string;
+}
+
+export interface SharedChatMessagesEventV1 {
+  version: "v1";
+  kind: "chat.messages";
+  shareId: string;
+  dashboardId: string;
+  publishedWidgetId: string;
+  widgetTitle: string;
+  at: string;
+  messages: SharedChatMessage[];
+}
+
+export type SharedSessionEventV1 =
+  | SharedDashboardStateEventV1
+  | SharedTraceEventEnvelopeV1
+  | SharedChatMessagesEventV1;
+
+export interface SharedWidgetChat {
+  publishedWidgetId: string;
+  widgetTitle: string;
+  messages: SharedChatMessage[];
+}
+
+export interface SharedSessionSnapshotV1 {
+  version: "v1";
+  shareId: string;
+  dashboard: DashboardSharedStateV1 | null;
+  trace: SharedTraceStateV1;
+  chats: SharedWidgetChat[];
+  replayEvents: SharedSessionEventV1[];
+  updatedAt: string;
+}
+
+export interface SharedSessionReplayFrameV1 {
+  traceEvent: PublishedTraceEventV1 | null;
+  endEventIndex: number;
+}
+
+// ── Zod schemas ──
+
+const CanvasLayoutSchema = z.object({ x: z.number(), y: z.number(), w: z.number(), h: z.number() });
+
+const TraceEventKindSchema = z.enum(["run-start", "tool-call", "file-written", "run-finished", "run-abort", "run-error"]);
+
+const PublishedTraceEventV1Schema = z.object({
+  id: z.string(), runId: z.string(), shareId: z.string(),
+  publishedWidgetId: z.string(), widgetTitle: z.string(),
+  kind: TraceEventKindSchema, at: z.string(), detail: z.string(),
+  toolName: z.string().optional(), path: z.string().optional(),
+});
+
+const CanvasViewportSchema = z.object({ panX: z.number(), panY: z.number(), zoom: z.number() });
+
+const DashboardSharedStateV1Schema = z.object({
+  version: z.literal("v1"), shareId: z.string(), dashboardId: z.string(),
+  title: z.string(), updatedAt: z.string(),
+  viewport: CanvasViewportSchema.nullable().optional(),
+  textBlocks: z.array(z.object({ id: z.string(), text: z.string(), fontSize: z.number(), layout: CanvasLayoutSchema })),
+  widgets: z.array(z.object({
+    sourceWidgetId: z.string(), publishedWidgetId: z.string(), revision: z.string(),
+    title: z.string(), description: z.string(), layout: CanvasLayoutSchema,
+    files: z.record(z.string(), z.string()),
+  })),
+});
+
+const SharedDashboardStateEventV1Schema = z.object({
+  version: z.literal("v1"), kind: z.literal("dashboard.state"),
+  shareId: z.string(), dashboardId: z.string(), at: z.string(),
+  stateHash: z.string(), state: DashboardSharedStateV1Schema,
+});
+
+const SharedTraceEventEnvelopeV1Schema = z.object({
+  version: z.literal("v1"), kind: z.literal("trace.event"),
+  shareId: z.string(), dashboardId: z.string(), at: z.string(),
+  event: PublishedTraceEventV1Schema,
+});
+
+const SharedChatMessageSchema = z.object({
+  id: z.string(), role: z.enum(["user", "assistant"]), content: z.string(),
+  reasoning: z.string().optional(),
+});
+
+const SharedChatMessagesEventV1Schema = z.object({
+  version: z.literal("v1"), kind: z.literal("chat.messages"),
+  shareId: z.string(), dashboardId: z.string(),
+  publishedWidgetId: z.string(), widgetTitle: z.string(), at: z.string(),
+  messages: z.array(SharedChatMessageSchema),
+});
+
+export const SharedSessionEventV1Schema = z.union([
+  SharedDashboardStateEventV1Schema,
+  SharedTraceEventEnvelopeV1Schema,
+  SharedChatMessagesEventV1Schema,
+]);
+
+const SharedTraceStateV1Schema = z.object({
+  version: z.literal("v1"), shareId: z.string(), updatedAt: z.string(),
+  nextOffset: z.string().nullable().optional(), events: z.array(PublishedTraceEventV1Schema),
+});
+
+const SharedWidgetChatSchema = z.object({
+  publishedWidgetId: z.string(), widgetTitle: z.string(),
+  messages: z.array(SharedChatMessageSchema),
+});
+
+export const SharedSessionSnapshotV1Schema = z.object({
+  version: z.literal("v1"), shareId: z.string(), updatedAt: z.string(),
+  dashboard: DashboardSharedStateV1Schema.nullable(),
+  trace: SharedTraceStateV1Schema,
+  chats: z.array(SharedWidgetChatSchema).optional(),
+  replayEvents: z.array(SharedSessionEventV1Schema),
+});
+
+// ── Empty state builders ──
+
+export function buildEmptySharedTraceState(shareId: string, updatedAt = new Date().toISOString()): SharedTraceStateV1 {
+  return { version: "v1", shareId, updatedAt, nextOffset: null, events: [] };
+}
+
+export function buildEmptySharedSessionSnapshot(shareId: string, updatedAt = new Date().toISOString()): SharedSessionSnapshotV1 {
+  return { version: "v1", shareId, dashboard: null, trace: buildEmptySharedTraceState(shareId, updatedAt), chats: [], replayEvents: [], updatedAt };
+}
+
+// ── Reducer ──
+
+function reduceSlices(snapshot: SharedSessionSnapshotV1, event: SharedSessionEventV1): SharedSessionSnapshotV1 {
+  switch (event.kind) {
+    case "dashboard.state":
+      return { ...snapshot, dashboard: event.state, updatedAt: event.at };
+    case "trace.event": {
+      const events = [...snapshot.trace.events, event.event].slice(-MAX_SHARED_TRACE_EVENTS);
+      return { ...snapshot, trace: { ...snapshot.trace, updatedAt: event.at, events }, updatedAt: event.at };
+    }
+    case "chat.messages": {
+      const chats = (snapshot.chats ?? []).filter((c) => c.publishedWidgetId !== event.publishedWidgetId);
+      chats.push({ publishedWidgetId: event.publishedWidgetId, widgetTitle: event.widgetTitle, messages: event.messages });
+      return { ...snapshot, chats, updatedAt: event.at };
+    }
+  }
+}
+
+function trimReplayEvents(events: SharedSessionEventV1[], maxTrace = MAX_SHARED_TRACE_EVENTS): SharedSessionEventV1[] {
+  if (events.length === 0) return events;
+  const traceIndices = events.flatMap((e, i) => (e.kind === "trace.event" ? [i] : []));
+  if (traceIndices.length === 0) {
+    const lastDash = events.findLastIndex((e) => e.kind === "dashboard.state");
+    return lastDash >= 0 ? events.slice(lastDash) : events.slice(-1);
+  }
+  const firstKeep = traceIndices[Math.max(0, traceIndices.length - maxTrace)];
+  const lastDashBefore = events.slice(0, firstKeep).findLastIndex((e) => e.kind === "dashboard.state");
+  const start = lastDashBefore >= 0 ? lastDashBefore : firstKeep;
+  return events.slice(start);
+}
+
+export function applySharedSessionEvent(snapshot: SharedSessionSnapshotV1, event: SharedSessionEventV1): SharedSessionSnapshotV1 {
+  return {
+    ...reduceSlices(snapshot, event),
+    replayEvents: trimReplayEvents([...snapshot.replayEvents, event]),
+  };
+}
+
+// ── Replay helpers ──
+
+export function buildSharedSessionReplayFrames(
+  replayEvents: SharedSessionEventV1[],
+  publishedWidgetId?: string,
+): SharedSessionReplayFrameV1[] {
+  const allTraceIndices = replayEvents.flatMap((e, i) => (e.kind === "trace.event" ? [i] : []));
+  const traceIndices = replayEvents.flatMap((e, i) =>
+    e.kind === "trace.event" && (!publishedWidgetId || e.event.publishedWidgetId === publishedWidgetId) ? [i] : [],
+  );
+  if (traceIndices.length === 0) return [];
+
+  const frames: SharedSessionReplayFrameV1[] = [{ traceEvent: null, endEventIndex: traceIndices[0] }];
+  for (const eventIndex of traceIndices) {
+    const event = replayEvents[eventIndex];
+    if (event?.kind !== "trace.event") continue;
+    const nextTrace = allTraceIndices.find((i) => i > eventIndex);
+    frames.push({ traceEvent: event.event, endEventIndex: nextTrace ?? replayEvents.length });
+  }
+  return frames;
+}
+
+export function buildSharedSessionReplaySnapshot(
+  shareId: string,
+  replayEvents: SharedSessionEventV1[],
+  frameIndex: number,
+  publishedWidgetId?: string,
+): SharedSessionSnapshotV1 {
+  const frames = buildSharedSessionReplayFrames(replayEvents, publishedWidgetId);
+  if (frames.length === 0) return { ...buildEmptySharedSessionSnapshot(shareId), replayEvents };
+  const safeIndex = Math.max(0, Math.min(frameIndex, frames.length - 1));
+  const endIndex = frames[safeIndex]?.endEventIndex ?? replayEvents.length;
+  let snapshot = buildEmptySharedSessionSnapshot(shareId);
+  for (const event of replayEvents.slice(0, endIndex)) {
+    snapshot = reduceSlices(snapshot, event);
+  }
+  return { ...snapshot, replayEvents };
+}
+
+function isTerminalKind(kind: PublishedTraceEventKind) {
+  return kind === "run-finished" || kind === "run-abort" || kind === "run-error";
+}
+
+export function findActiveSharedTraceEvent(
+  events: PublishedTraceEventV1[],
+  publishedWidgetId?: string,
+): PublishedTraceEventV1 | null {
+  const closedRuns = new Set<string>();
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (publishedWidgetId && e.publishedWidgetId !== publishedWidgetId) continue;
+    if (isTerminalKind(e.kind)) { closedRuns.add(e.runId); continue; }
+    if (closedRuns.has(e.runId)) continue;
+    return e;
+  }
+  return null;
+}
+
+export function findLatestSharedTraceEvent(
+  events: PublishedTraceEventV1[],
+  publishedWidgetId?: string,
+): PublishedTraceEventV1 | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (publishedWidgetId && e.publishedWidgetId !== publishedWidgetId) continue;
+    return e;
+  }
+  return null;
+}
+
+export function mergeFocusedWidgetReplayDashboard(
+  liveDashboard: DashboardSharedStateV1 | null,
+  replayDashboard: DashboardSharedStateV1 | null,
+  focusedWidgetId: string | null,
+): DashboardSharedStateV1 | null {
+  if (!focusedWidgetId) return replayDashboard ?? liveDashboard;
+  if (!liveDashboard) return replayDashboard;
+  if (!replayDashboard) return liveDashboard;
+  const replayWidget = replayDashboard.widgets.find((w) => w.publishedWidgetId === focusedWidgetId);
+  if (!replayWidget) return liveDashboard;
+  const hasLive = liveDashboard.widgets.some((w) => w.publishedWidgetId === focusedWidgetId);
+  return {
+    ...liveDashboard,
+    widgets: hasLive
+      ? liveDashboard.widgets.map((w) =>
+          w.publishedWidgetId === focusedWidgetId
+            ? { ...w, title: replayWidget.title, description: replayWidget.description, revision: replayWidget.revision, files: replayWidget.files }
+            : w,
+        )
+      : [...liveDashboard.widgets, replayWidget],
+  };
+}

--- a/src/lib/share-types.ts
+++ b/src/lib/share-types.ts
@@ -123,13 +123,7 @@ export interface SharedSessionSnapshotV1 {
   dashboard: DashboardSharedStateV1 | null;
   trace: SharedTraceStateV1;
   chats: SharedWidgetChat[];
-  replayEvents: SharedSessionEventV1[];
   updatedAt: string;
-}
-
-export interface SharedSessionReplayFrameV1 {
-  traceEvent: PublishedTraceEventV1 | null;
-  endEventIndex: number;
 }
 
 // ── Zod schemas ──
@@ -204,7 +198,6 @@ export const SharedSessionSnapshotV1Schema = z.object({
   dashboard: DashboardSharedStateV1Schema.nullable(),
   trace: SharedTraceStateV1Schema,
   chats: z.array(SharedWidgetChatSchema).optional(),
-  replayEvents: z.array(SharedSessionEventV1Schema),
 });
 
 // ── Empty state builders ──
@@ -214,7 +207,7 @@ export function buildEmptySharedTraceState(shareId: string, updatedAt = new Date
 }
 
 export function buildEmptySharedSessionSnapshot(shareId: string, updatedAt = new Date().toISOString()): SharedSessionSnapshotV1 {
-  return { version: "v1", shareId, dashboard: null, trace: buildEmptySharedTraceState(shareId, updatedAt), chats: [], replayEvents: [], updatedAt };
+  return { version: "v1", shareId, dashboard: null, trace: buildEmptySharedTraceState(shareId, updatedAt), chats: [], updatedAt };
 }
 
 // ── Reducer ──
@@ -235,115 +228,6 @@ function reduceSlices(snapshot: SharedSessionSnapshotV1, event: SharedSessionEve
   }
 }
 
-function trimReplayEvents(events: SharedSessionEventV1[], maxTrace = MAX_SHARED_TRACE_EVENTS): SharedSessionEventV1[] {
-  if (events.length === 0) return events;
-  const traceIndices = events.flatMap((e, i) => (e.kind === "trace.event" ? [i] : []));
-  if (traceIndices.length === 0) {
-    const lastDash = events.findLastIndex((e) => e.kind === "dashboard.state");
-    return lastDash >= 0 ? events.slice(lastDash) : events.slice(-1);
-  }
-  const firstKeep = traceIndices[Math.max(0, traceIndices.length - maxTrace)];
-  const lastDashBefore = events.slice(0, firstKeep).findLastIndex((e) => e.kind === "dashboard.state");
-  const start = lastDashBefore >= 0 ? lastDashBefore : firstKeep;
-  return events.slice(start);
-}
-
 export function applySharedSessionEvent(snapshot: SharedSessionSnapshotV1, event: SharedSessionEventV1): SharedSessionSnapshotV1 {
-  return {
-    ...reduceSlices(snapshot, event),
-    replayEvents: trimReplayEvents([...snapshot.replayEvents, event]),
-  };
-}
-
-// ── Replay helpers ──
-
-export function buildSharedSessionReplayFrames(
-  replayEvents: SharedSessionEventV1[],
-  publishedWidgetId?: string,
-): SharedSessionReplayFrameV1[] {
-  const allTraceIndices = replayEvents.flatMap((e, i) => (e.kind === "trace.event" ? [i] : []));
-  const traceIndices = replayEvents.flatMap((e, i) =>
-    e.kind === "trace.event" && (!publishedWidgetId || e.event.publishedWidgetId === publishedWidgetId) ? [i] : [],
-  );
-  if (traceIndices.length === 0) return [];
-
-  const frames: SharedSessionReplayFrameV1[] = [{ traceEvent: null, endEventIndex: traceIndices[0] }];
-  for (const eventIndex of traceIndices) {
-    const event = replayEvents[eventIndex];
-    if (event?.kind !== "trace.event") continue;
-    const nextTrace = allTraceIndices.find((i) => i > eventIndex);
-    frames.push({ traceEvent: event.event, endEventIndex: nextTrace ?? replayEvents.length });
-  }
-  return frames;
-}
-
-export function buildSharedSessionReplaySnapshot(
-  shareId: string,
-  replayEvents: SharedSessionEventV1[],
-  frameIndex: number,
-  publishedWidgetId?: string,
-): SharedSessionSnapshotV1 {
-  const frames = buildSharedSessionReplayFrames(replayEvents, publishedWidgetId);
-  if (frames.length === 0) return { ...buildEmptySharedSessionSnapshot(shareId), replayEvents };
-  const safeIndex = Math.max(0, Math.min(frameIndex, frames.length - 1));
-  const endIndex = frames[safeIndex]?.endEventIndex ?? replayEvents.length;
-  let snapshot = buildEmptySharedSessionSnapshot(shareId);
-  for (const event of replayEvents.slice(0, endIndex)) {
-    snapshot = reduceSlices(snapshot, event);
-  }
-  return { ...snapshot, replayEvents };
-}
-
-function isTerminalKind(kind: PublishedTraceEventKind) {
-  return kind === "run-finished" || kind === "run-abort" || kind === "run-error";
-}
-
-export function findActiveSharedTraceEvent(
-  events: PublishedTraceEventV1[],
-  publishedWidgetId?: string,
-): PublishedTraceEventV1 | null {
-  const closedRuns = new Set<string>();
-  for (let i = events.length - 1; i >= 0; i--) {
-    const e = events[i];
-    if (publishedWidgetId && e.publishedWidgetId !== publishedWidgetId) continue;
-    if (isTerminalKind(e.kind)) { closedRuns.add(e.runId); continue; }
-    if (closedRuns.has(e.runId)) continue;
-    return e;
-  }
-  return null;
-}
-
-export function findLatestSharedTraceEvent(
-  events: PublishedTraceEventV1[],
-  publishedWidgetId?: string,
-): PublishedTraceEventV1 | null {
-  for (let i = events.length - 1; i >= 0; i--) {
-    const e = events[i];
-    if (publishedWidgetId && e.publishedWidgetId !== publishedWidgetId) continue;
-    return e;
-  }
-  return null;
-}
-
-export function mergeFocusedWidgetReplayDashboard(
-  liveDashboard: DashboardSharedStateV1 | null,
-  replayDashboard: DashboardSharedStateV1 | null,
-  focusedWidgetId: string | null,
-): DashboardSharedStateV1 | null {
-  if (!focusedWidgetId) return replayDashboard ?? liveDashboard;
-  if (!liveDashboard) return replayDashboard;
-  if (!replayDashboard) return liveDashboard;
-  const replayWidget = replayDashboard.widgets.find((w) => w.publishedWidgetId === focusedWidgetId);
-  if (!replayWidget) return liveDashboard;
-  const hasLive = liveDashboard.widgets.some((w) => w.publishedWidgetId === focusedWidgetId);
-  return {
-    ...liveDashboard,
-    widgets: hasLive
-      ? liveDashboard.widgets.map((w) =>
-          w.publishedWidgetId === focusedWidgetId
-            ? { ...w, title: replayWidget.title, description: replayWidget.description, revision: replayWidget.revision, files: replayWidget.files }
-            : w,
-        )
-      : [...liveDashboard.widgets, replayWidget],
-  };
+  return reduceSlices(snapshot, event);
 }

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,28 @@
+import { createHmac } from "node:crypto";
+
+export const SHARE_BUCKET = "im-share";
+
+function getShareSecret(explicit?: string) {
+  const secret = explicit ?? process.env.SHARE_ID_SECRET;
+  if (!secret) throw new Error("SHARE_ID_SECRET is not set");
+  return secret;
+}
+
+export function deriveShareId(dashboardId: string, explicitSecret?: string) {
+  const digest = createHmac("sha256", getShareSecret(explicitSecret))
+    .update(dashboardId)
+    .digest("base64url");
+  return `shr_${digest.slice(0, 22)}`;
+}
+
+export function getSessionStreamId(shareId: string) {
+  return `${shareId}.session`;
+}
+
+export function getPublishedWidgetId(shareId: string, sourceWidgetId: string) {
+  return `share--${shareId}--${sourceWidgetId}`;
+}
+
+export function isPublishedWidgetId(widgetId: string) {
+  return widgetId.startsWith("share--");
+}

--- a/src/lib/sync-db.ts
+++ b/src/lib/sync-db.ts
@@ -1,59 +1,140 @@
-import { useWidgetStore } from "@/store/widget-store";
+import type { CanvasViewport } from "@/store/widget-store";
 
+export interface SyncDashboardPayload {
+  id: string;
+  title: string;
+  widgetIds: string[];
+  textBlockIds: string[];
+  createdAt: number;
+  viewport?: CanvasViewport;
+}
+
+export interface SyncWidgetPayload {
+  id: string;
+  title: string;
+  description: string;
+  code: string | null;
+  files?: Record<string, string>;
+  layout: unknown;
+  messages: unknown[];
+}
+
+export interface SyncTextBlockPayload {
+  id: string;
+  text: string;
+  fontSize: number;
+  layout: unknown;
+}
+
+export interface SyncPayload {
+  dashboards: SyncDashboardPayload[];
+  widgets: SyncWidgetPayload[];
+  textBlocks: SyncTextBlockPayload[];
+  dirtyDashboardIds?: string[];
+}
+
+export type SyncUrgency = "interactive" | "background";
+
+const DEBOUNCE_INTERACTIVE = 250;
+const DEBOUNCE_BACKGROUND = 2000;
+
+let payloadProvider: (() => SyncPayload) | null = null;
 let syncTimeout: ReturnType<typeof setTimeout> | null = null;
+let currentUrgency: SyncUrgency = "background";
+let syncLoopTask: Promise<void> | null = null;
+const pendingDirtyDashboardIds = new Set<string>();
+let pendingResync = false;
 
-export function scheduleSyncToServer() {
-  if (syncTimeout) clearTimeout(syncTimeout);
-  syncTimeout = setTimeout(() => {
-    const { dashboards, widgets, textBlocks } = useWidgetStore.getState();
-    fetch("/api/sync", {
+export function configureSyncPayloadProvider(provider: () => SyncPayload) {
+  payloadProvider = provider;
+}
+
+function getDelay(urgency: SyncUrgency) {
+  return urgency === "interactive" ? DEBOUNCE_INTERACTIVE : DEBOUNCE_BACKGROUND;
+}
+
+async function syncNow() {
+  if (!payloadProvider) return;
+  const dirtyIds = [...pendingDirtyDashboardIds];
+  pendingDirtyDashboardIds.clear();
+  pendingResync = false;
+
+  const payload = payloadProvider();
+  payload.dirtyDashboardIds = dirtyIds.length > 0 ? dirtyIds : undefined;
+
+  try {
+    await fetch("/api/sync", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        dashboards: dashboards.map((d) => ({
-          id: d.id,
-          title: d.title,
-          widgetIds: d.widgetIds,
-          textBlockIds: d.textBlockIds ?? [],
-          createdAt: d.createdAt,
-        })),
-        widgets: widgets.map((w) => ({
-          id: w.id,
-          title: w.title,
-          description: w.description,
-          code: w.code,
-          layout: w.layout,
-          messages: w.messages,
-        })),
-        textBlocks: textBlocks.map((tb) => ({
-          id: tb.id,
-          text: tb.text,
-          fontSize: tb.fontSize,
-          layout: tb.layout,
-        })),
-      }),
-    }).catch(() => {});
-  }, 2000);
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    for (const id of dirtyIds) pendingDirtyDashboardIds.add(id);
+  }
+}
+
+async function runSyncLoop() {
+  await syncNow();
+  while (pendingResync) {
+    await syncNow();
+  }
+  syncLoopTask = null;
+}
+
+function triggerSync() {
+  if (syncLoopTask) {
+    pendingResync = true;
+    return;
+  }
+  syncLoopTask = runSyncLoop();
+}
+
+export function scheduleSyncToServer(options?: {
+  urgency?: SyncUrgency;
+  dirtyDashboardIds?: string[];
+}) {
+  const urgency = options?.urgency ?? "background";
+  for (const id of options?.dirtyDashboardIds ?? []) {
+    pendingDirtyDashboardIds.add(id);
+  }
+
+  if (syncTimeout && urgency === "interactive" && currentUrgency === "background") {
+    clearTimeout(syncTimeout);
+    syncTimeout = null;
+  }
+
+  if (!syncTimeout) {
+    currentUrgency = urgency;
+    syncTimeout = setTimeout(() => {
+      syncTimeout = null;
+      triggerSync();
+    }, getDelay(urgency));
+  }
+}
+
+export function deleteWidgetFromDb(_widgetId: string) {
+  scheduleSyncToServer();
+}
+
+export function deleteTextBlockFromDb(_textBlockId: string) {
+  scheduleSyncToServer();
 }
 
 export function syncWidgetToDb() {
   scheduleSyncToServer();
 }
 
-export function deleteWidgetFromDb(widgetId: string) {
-  fetch("/api/widgets", {
-    method: "DELETE",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id: widgetId }),
-  }).catch(() => {});
-  scheduleSyncToServer();
-}
-
-export function deleteTextBlockFromDb(textBlockId: string) {
-  fetch("/api/text-blocks", {
-    method: "DELETE",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id: textBlockId }),
-  }).catch(() => {});
-  scheduleSyncToServer();
+export async function flushSyncToServer(options?: { dirtyDashboardIds?: string[] }) {
+  for (const id of options?.dirtyDashboardIds ?? []) {
+    pendingDirtyDashboardIds.add(id);
+  }
+  if (syncTimeout) {
+    clearTimeout(syncTimeout);
+    syncTimeout = null;
+  }
+  if (syncLoopTask) {
+    pendingResync = true;
+    await syncLoopTask;
+  }
+  await syncNow();
 }

--- a/src/store/widget-store.ts
+++ b/src/store/widget-store.ts
@@ -1,5 +1,11 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { DEFAULT_CANVAS_VIEWPORT } from "@/lib/canvas-viewport";
+import {
+  configureSyncPayloadProvider,
+  type SyncPayload,
+  type SyncUrgency,
+} from "@/lib/sync-db";
 
 export interface MessageAttachment {
   name: string;
@@ -55,9 +61,16 @@ export interface Dashboard {
   createdAt: number;
 }
 
+export interface SavedShare {
+  shareId: string;
+  title: string;
+  savedAt: number;
+}
+
 interface WidgetStore {
   dashboards: Dashboard[];
   activeDashboardId: string | null;
+  savedShares: SavedShare[];
   widgets: Widget[];
   textBlocks: TextBlock[];
   activeWidgetId: string | null;
@@ -73,6 +86,7 @@ interface WidgetStore {
 
   addWidget: (title?: string, description?: string) => string;
   addMessage: (widgetId: string, message: WidgetMessage) => void;
+  updateMessageContent: (widgetId: string, messageId: string, content: string) => void;
   renameWidget: (id: string, title: string) => void;
   setWidgetCode: (widgetId: string, code: string) => void;
   setWidgetFile: (widgetId: string, path: string, content: string) => void;
@@ -96,6 +110,9 @@ interface WidgetStore {
       layoutJson: string | null;
     }>;
   }) => void;
+
+  saveShare: (shareId: string, title: string) => void;
+  removeShare: (shareId: string) => void;
 
   addTextBlock: (position?: { x: number; y: number }) => string;
   updateTextBlock: (id: string, updates: Partial<Pick<TextBlock, "text" | "fontSize">>) => void;
@@ -166,6 +183,7 @@ export const useWidgetStore = create<WidgetStore>()(
     (set, get) => ({
       dashboards: [],
       activeDashboardId: null,
+      savedShares: [],
       widgets: [],
       textBlocks: [],
       activeWidgetId: null,
@@ -173,6 +191,21 @@ export const useWidgetStore = create<WidgetStore>()(
       currentActions: {},
       reasoningStreamingIds: [],
       viewports: {},
+
+      saveShare: (shareId, title) => {
+        set((state) => ({
+          savedShares: [
+            ...state.savedShares.filter((s) => s.shareId !== shareId),
+            { shareId, title, savedAt: Date.now() },
+          ],
+        }));
+      },
+
+      removeShare: (shareId) => {
+        set((state) => ({
+          savedShares: state.savedShares.filter((s) => s.shareId !== shareId),
+        }));
+      },
 
       addDashboard: (title = "Dashboard") => {
         const id = generateId("dash");
@@ -268,6 +301,16 @@ export const useWidgetStore = create<WidgetStore>()(
           widgets: get().widgets.map((w) =>
             w.id === widgetId
               ? { ...w, messages: [...w.messages, message] }
+              : w
+          ),
+        });
+      },
+
+      updateMessageContent: (widgetId, messageId, content) => {
+        set({
+          widgets: get().widgets.map((w) =>
+            w.id === widgetId
+              ? { ...w, messages: w.messages.map((m) => m.id === messageId ? { ...m, content } : m) }
               : w
           ),
         });
@@ -604,6 +647,7 @@ export const useWidgetStore = create<WidgetStore>()(
           streamingWidgetIds: [],
           currentActions: {},
           reasoningStreamingIds: [],
+          savedShares: stored.savedShares ?? [],
           viewports: migrateViewports(stored.viewports),
           widgets,
           textBlocks,
@@ -612,3 +656,35 @@ export const useWidgetStore = create<WidgetStore>()(
     }
   )
 );
+
+type DurableStoreState = Pick<WidgetStore, "dashboards" | "widgets" | "textBlocks" | "viewports">;
+
+export function buildSyncPayloadFromStoreState(state: DurableStoreState): SyncPayload {
+  return {
+    dashboards: state.dashboards.map((d) => ({
+      id: d.id,
+      title: d.title,
+      widgetIds: d.widgetIds,
+      textBlockIds: d.textBlockIds ?? [],
+      createdAt: d.createdAt,
+      viewport: state.viewports[d.id] ?? DEFAULT_CANVAS_VIEWPORT,
+    })),
+    widgets: state.widgets.map((w) => ({
+      id: w.id,
+      title: w.title,
+      description: w.description,
+      code: w.code,
+      files: w.files,
+      layout: w.layout,
+      messages: w.messages,
+    })),
+    textBlocks: state.textBlocks.map((tb) => ({
+      id: tb.id,
+      text: tb.text,
+      fontSize: tb.fontSize,
+      layout: tb.layout,
+    })),
+  };
+}
+
+configureSyncPayloadProvider(() => buildSyncPayloadFromStoreState(useWidgetStore.getState()));


### PR DESCRIPTION
Trim and make implementation cleaner compare than #54.

## How it works

Author edits dashboard -> Zustand -> /api/sync -> SQLite (cache) + if shared: project → append to durable stream (source of truth). Viewer fetches initial state via bootstrap API, then connects directly to durable stream SSE for real-time updates.

## Quick verification

1. Author clicks Share -> create durable stream -> project current dashboard state -> append
2. On every subsequent sync (layout/widget/text edits) -> hash dedup -> project -> append
3. During AI chat -> trace events + full chat messages appended to stream
4. Viewer opens share URL -> bootstrap for snapshot -> SSE for real-time updates -> click widget to view its chat session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new sharing/publishing flow that writes dashboard state and chat/trace events to an external durable-stream service and updates DB sync semantics; failures or schema mismatches could break live share or cause unintended data persistence.
> 
> **Overview**
> Adds **stable dashboard sharing** backed by a durable stream: a new `POST /api/dashboards/[id]/share` creates a per-dashboard stream (stable `shareId`) and publishes a projected dashboard snapshot, and a new `GET /api/share/[shareId]/bootstrap` returns the reconstructed snapshot plus an SSE URL for live updates.
> 
> Updates syncing/persistence to support sharing: `/api/sync` now accepts `dirtyDashboardIds` and, when a dashboard is shared, projects state (widgets, text blocks, *viewport*) and appends deduped `dashboard.state` events while materializing published widgets locally for iframe serving.
> 
> Extends chat streaming to record share session telemetry: `/api/chat` now emits durable-stream trace events (tool calls, file writes, run lifecycle) and flushes the full assistant response + message history as `chat.messages`, and widget rebuilds trigger republishing when shared.
> 
> Adds UI and store support for viewing shared dashboards at `/share/[shareId]`, saving recent shares, and a `ShareDashboardButton`; also adds `viewport_json` to the dashboards table and refactors sync payload generation/debouncing in `sync-db`, with tests for share IDs and shared session event reducers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96b5515aff29be27069d6d5b0e3c3afb9b0d72b1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->