### PR TITLE
add desktop app option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
+## Desktop app
+
+If you want to run Infinite Monitor as an installable desktop app instead of
+starting the web app from source, there is a community-maintained Electron
+distribution for macOS, Windows, and Linux:
+
+- Desktop repo: [mehdiraized/infinite-monitor-desktop](https://github.com/mehdiraized/infinite-monitor-desktop)
+- Latest releases: [Download desktop builds](https://github.com/mehdiraized/infinite-monitor-desktop/releases/latest)
+
+The desktop project tracks this repository as its upstream source and adds
+desktop-specific packaging and integrations in a separate repository.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
Summary
Adds a short Desktop app section to the main README so users who prefer an installable build can discover the community-maintained desktop distribution.

Why
Some users land on the main repository first, but the README currently only describes running Infinite Monitor from source. This change adds a small, clearly-labeled path for people who want a packaged desktop app on macOS, Windows, or Linux.

Notes
Keeps the mention intentionally short and non-intrusive
Labels the desktop build as community-maintained and separate from upstream
Links both the desktop repository and the latest release page
Testing
Documentation-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds external links and does not affect runtime code paths.
> 
> **Overview**
> Adds a new **Desktop app** section to `README.md` pointing users to a community-maintained Electron distribution, including links to the desktop repo and latest releases, and clarifying it is a separate project tracking this repo upstream.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb418dcb4c8542b2c0ebb3b917c5fb93830bea18. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->