### PR TITLE
fix: serialize cached widget restores

### DIFF
--- a/src/lib/widget-runner.ts
+++ b/src/lib/widget-runner.ts
@@ -52,6 +52,7 @@ interface WidgetSandbox {
 const widgetSandboxes = new Map<string, WidgetSandbox>();
 const widgetStatuses = new Map<string, WidgetStatus>();
 const buildLocks = new Map<string, Promise<void>>();
+const restoreLocks = new Map<string, Promise<WidgetStatus | null>>();
 
 const DB_PATH =
 	process.env.DATABASE_PATH || join(process.cwd(), "data", "widgets.db");
@@ -237,6 +238,28 @@ async function restoreWidgetFromCache(
 		}
 		rmSync(cached.rootDir, { recursive: true, force: true });
 		return null;
+	}
+}
+
+async function restoreCachedWidget(
+	widgetId: string,
+	previousStatus?: WidgetStatus,
+): Promise<WidgetStatus | null> {
+	const existingRestore = restoreLocks.get(widgetId);
+	if (existingRestore) return await existingRestore;
+
+	widgetStatuses.set(widgetId, {
+		status: "building",
+		port: previousStatus?.port ?? 0,
+		startedAt: Date.now(),
+	});
+
+	const promise = restoreWidgetFromCache(widgetId);
+	restoreLocks.set(widgetId, promise);
+	try {
+		return await promise;
+	} finally {
+		restoreLocks.delete(widgetId);
 	}
 }
 
@@ -721,7 +744,7 @@ async function doBuild(widgetId: string): Promise<void> {
 			/* */
 		}
 
-		runtime = createWidgetRuntime(cachedDistDir);
+		runtime = createWidgetRuntime(dirname(cachedDistDir));
 		startFileServer(runtime, cachedDistDir, port);
 		await waitForServer(`http://127.0.0.1:${port}/`);
 
@@ -782,14 +805,17 @@ export async function ensureWidget(widgetId: string): Promise<WidgetStatus> {
 		Date.now() - existing.startedAt > BUILD_TIMEOUT_MS;
 	if (existing?.status === "building" && !isStale) return existing;
 
-	const restored = await restoreWidgetFromCache(widgetId);
+	const restored = await restoreCachedWidget(widgetId, existing);
 	if (restored) return restored;
 
 	const shouldRetryError =
 		existing?.status === "error" &&
 		existing.startedAt &&
 		Date.now() - existing.startedAt > ERROR_RETRY_MS;
-	if (existing?.status === "error" && !shouldRetryError) return existing;
+	if (existing?.status === "error" && !shouldRetryError) {
+		widgetStatuses.set(widgetId, existing);
+		return existing;
+	}
 
 	const port = await getPort({ port: portNumbers(4100, 4999) });
 	const status: WidgetStatus = {


### PR DESCRIPTION
## What

Fix two follow-up issues in the widget build cache flow:

- serialize cached widget restores so concurrent requests cannot restore the same widget at the same time
- keep the widget runtime working directory consistent between fresh-build and cache-restore paths

## Why

The first cache persistence PR fixed rebuilds on every restart, but it introduced a race during cache restore.

If multiple requests hit the same widget before the first restore completes, they could all enter the restore path concurrently. Each restore attempt disposes the previous runtime, so one request could return a `ready` status while another had already terminated the runtime it depended on.

Also, the runtime `cwd` differed depending on whether the widget was served from a fresh build or from cached output. The current file server uses absolute paths, but keeping `cwd` consistent avoids subtle behavior differences and makes the runtime setup more predictable.

## Test plan

- [ ] Tests pass locally
- [x] Tested manually

Manual verification:

- reviewed the restore path and confirmed concurrent restores are now guarded by a per-widget restore lock
- confirmed the status is set to an in-progress state before awaiting cache restore, so later callers do not start competing restores
- confirmed the upstream runtime now uses the same working directory convention in both fresh-build and cache-restore paths
- verified the modified files are free of editor/type errors after the change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches widget lifecycle/concurrency and runtime working-directory setup; mistakes could still cause transient bad statuses or serving failures under load, but the change is localized and guarded by per-widget locking.
> 
> **Overview**
> Prevents races during widget cache restoration by adding a per-widget `restoreLocks` gate and setting an in-progress `building` status before awaiting the restore, so concurrent `ensureWidget` calls share the same restore attempt.
> 
> Aligns runtime behavior between build paths by creating the widget runtime with the cache root directory (not the `dist` directory) after a fresh build, matching the cache-restore `cwd` convention, and preserves existing error status without triggering competing restores/rebuilds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f9558d2e58fc2bb43fa539556a0ed88d86613a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->